### PR TITLE
Testing: Use unique names when running multiple test container instances

### DIFF
--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -71,6 +71,7 @@ class CrateDBContainer(KeepaliveContainer, DbContainer):
         password: Optional[str] = None,
         dbname: Optional[str] = None,
         cmd_opts: Optional[dict] = None,
+        name: Optional[str] = None,
         **kwargs,
     ) -> None:
         """
@@ -89,7 +90,7 @@ class CrateDBContainer(KeepaliveContainer, DbContainer):
         """
         super().__init__(image=image, **kwargs)
 
-        self._name = "testcontainers-cratedb"
+        self._name = name or "testcontainers-cratedb"
 
         cmd_opts = cmd_opts or {}
         self._command = self._build_cmd({**self.CMD_OPTS, **cmd_opts})
@@ -162,16 +163,17 @@ class CrateDBTestAdapter:
     CrateDB Toolkit's `DatabaseAdapter`, agnostic of the test framework.
     """
 
-    def __init__(self, crate_version: str = "nightly", **kwargs):
+    def __init__(self, crate_version: str = "nightly", name: str = None, **kwargs):
         self.cratedb: Optional[CrateDBContainer] = None
         self.database: Optional[DatabaseAdapter] = None
         self.image: str = "crate/crate:{}".format(crate_version)
+        self.name = name
 
     def start(self, **kwargs):
         """
         Start testcontainer, used for tests set up
         """
-        self.cratedb = CrateDBContainer(image=self.image, **kwargs)
+        self.cratedb = CrateDBContainer(image=self.image, name=self.name, **kwargs)
         self.cratedb.start()
         self.database = DatabaseAdapter(dburi=self.get_connection_url())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def cratedb_service():
     """
     Provide a CrateDB service instance to the test suite.
     """
-    db = CrateDBTestAdapter()
+    db = CrateDBTestAdapter(name="testcontainers-cratedb-custom")
     db.start(ports={CRATEDB_HTTP_PORT: None}, cmd_opts=CRATEDB_SETTINGS)
     db.reset(tables=RESET_TABLES)
     yield db


### PR DESCRIPTION
## About
When running multiple instances of `CrateDBTestAdapter` on behalf of software tests at GH-113, the process stalls, and times out.

```python
___________________ ERROR at setup of test_cratedb_service ___________________

    @pytest.fixture(scope="session")
    def cratedb_service() -> Generator[CrateDBTestAdapter, None, None]:
        """
        Provide a CrateDB service instance to the test suite.
        """
        db = CrateDBTestAdapter()
>       db.start()

cratedb_toolkit/testing/pytest.py:14:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cratedb_toolkit/testing/testcontainers/cratedb.py:178: in start
    self.database = DatabaseAdapter(dburi=self.get_connection_url())
cratedb_toolkit/testing/testcontainers/cratedb.py:200: in get_connection_url
    return self.cratedb.get_connection_url(*args, **kwargs)
cratedb_toolkit/testing/testcontainers/cratedb.py:144: in get_connection_url
    return super()._create_connection_url(
.venv/lib/python3.11/site-packages/testcontainers/core/generic.py:44: in _create_connection_url
    port = self.get_exposed_port(port)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

wrapped = <bound method DockerContainer.get_exposed_port of <cratedb_toolkit.testing.testcontainers.cratedb.CrateDBContainer object at 0x1233b0a90>>
instance = <cratedb_toolkit.testing.testcontainers.cratedb.CrateDBContainer object at 0x1233b0a90>, args = (4200,), kwargs = {}

    @wrapt.decorator
    def wrapper(wrapped, instance, args, kwargs):
        exception = None
        logger.info("Waiting to be ready...")
        for attempt_no in range(config.MAX_TRIES):
            try:
                return wrapped(*args, **kwargs)
            except transient_exceptions as e:
                logger.debug(f"Connection attempt '{attempt_no + 1}' of '{config.MAX_TRIES + 1}' "
                             f"failed: {traceback.format_exc()}")
                time.sleep(config.SLEEP_TIME)
                exception = e
>       raise TimeoutException(
            f'Wait time ({config.MAX_TRIES * config.SLEEP_TIME}s) exceeded for {wrapped.__name__}'
            f'(args: {args}, kwargs {kwargs}). Exception: {exception}'
        )
E       testcontainers.core.exceptions.TimeoutException: Wait time (120s) exceeded for get_exposed_port(args: (4200,), kwargs {}). Exception: port mapping for container d6aa8f92b128a39110957619f56ad071c5562384a9c91fec3adc4112ce3d7104 and port 4200 is not available

.venv/lib/python3.11/site-packages/testcontainers/core/waiting_utils.py:55: TimeoutException
```
