### PR TITLE
Setup: Fix package installation woes with `setuptools`/`backports.tarfile`, and `PyInstaller`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,12 +64,14 @@ jobs:
     - name: Set up project
       run: |
 
-        # `setuptools 0.64.0` adds support for editable install hooks (PEP 660).
+        # `setuptools 64` adds support for editable install hooks (PEP 660).
         # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
-        pip install "setuptools>=64" --upgrade
+        # `setuptools 71` significantly re-vendors setuptools packages, causing hiccups on Python 3.8.
+        # https://github.com/pypa/setuptools/pull/4457
+        pip install "setuptools>=64,<71" --upgrade
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[full,test,develop]
+        pip install --use-pep517 --prefer-binary --editable='.[full,test,develop]'
 
     - name: Run linter and software tests
       env:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -42,7 +42,16 @@ jobs:
         cache-dependency-path: 'pyproject.toml'
 
     - name: Set up project
-      run: pip install --use-pep517 --prefer-binary --editable='.[cfr,release-cfr]'
+      run: |
+
+        # `setuptools 64` adds support for editable install hooks (PEP 660).
+        # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
+        # `setuptools 71` significantly re-vendors setuptools packages, causing hiccups on Python 3.8.
+        # https://github.com/pypa/setuptools/pull/4457
+        pip install "setuptools>=64,<71" --upgrade
+
+        # Install package in editable mode.
+        pip install --use-pep517 --prefer-binary --editable='.[cfr,release-cfr]'
 
     - name: Build application bundle
       run: poe build-cfr


### PR DESCRIPTION
## About
Check why GH-196 fails, and resolve it.

## Investigations
### Details I
Fails on Python 3.8, with setuptools 70.3.0.

-- https://github.com/crate/cratedb-toolkit/actions/runs/9982521975/job/27589490156?pr=196#step:6:229
```
/path/to/lib/python3.8/site-packages/setuptools/_vendor/jaraco/context.py:17: ImportError
```
```python
ImportError: cannot import name 'tarfile' from 'backports' (/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/backports/__init__.py)
```

### Details II
Fails on all test matrix slots.
```
PyInstaller.exceptions.ImportErrorWhenRunningHook: Failed to import module __PyInstaller_hooks_0_importlib_metadata required by hook for module /opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/PyInstaller/hooks/hook-importlib_metadata.py. Please check whether module __PyInstaller_hooks_0_importlib_metadata actually exists and whether the hook is compatible with your version of /opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/PyInstaller/hooks/hook-importlib_metadata.py: You might want to read more about hooks in the manual and provide a pull-request to improve PyInstaller.
```
-- https://github.com/crate/cratedb-toolkit/actions/runs/9983011865/job/27589798960?pr=201#step:5:198

## Solution
Downgrade to `setuptools<71`.
