### PR TITLE
Core: Improve quoting for `TableAddress.fullname`

### DIFF
--- a/cratedb_toolkit/model.py
+++ b/cratedb_toolkit/model.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 
 from boltons.urlutils import URL
 
-from cratedb_toolkit.util.database import decode_database_table
+from cratedb_toolkit.util.database import DatabaseAdapter, decode_database_table
 
 
 @dataclasses.dataclass
@@ -85,12 +85,10 @@ class TableAddress:
 
     @property
     def fullname(self):
-        if self.schema is None and self.table is None:
-            raise ValueError("Uninitialized table address can not be serialized")
-        if self.schema and self.table:
-            return f'"{self.schema}"."{self.table}"'
-        else:
-            return f'"{self.table}"'
+        """
+        Return a full-qualified quoted table identifier.
+        """
+        return DatabaseAdapter.quote_relation_name(f"{self.schema}.{self.table}")
 
 
 @dataclasses.dataclass

--- a/tests/util/database.py
+++ b/tests/util/database.py
@@ -3,8 +3,11 @@ import pytest
 from cratedb_toolkit.util import DatabaseAdapter
 
 
-def test_quote_relation_name():
-    database = DatabaseAdapter(dburi="crate://localhost")
+def test_quote_relation_name_single():
+    """
+    Verify quoting a simple or full-qualified relation name.
+    """
+    database = DatabaseAdapter
     assert database.quote_relation_name("my_table") == "my_table"
     assert database.quote_relation_name("my-table") == '"my-table"'
     assert database.quote_relation_name("MyTable") == '"MyTable"'
@@ -17,7 +20,18 @@ def test_quote_relation_name():
     assert database.quote_relation_name("table") == '"table"'
 
 
+def test_quote_relation_name_double():
+    """
+    Verify quoting a relation name twice does not cause any harm.
+    """
+    database = DatabaseAdapter
+    input_fqn = "foo-bar.baz_qux"
+    output_fqn = '"foo-bar".baz_qux'
+    assert database.quote_relation_name(input_fqn) == output_fqn
+    assert database.quote_relation_name(output_fqn) == output_fqn
+
+
 def test_quote_relation_name_with_invalid_fqn():
-    database = DatabaseAdapter(dburi="crate://localhost")
+    database = DatabaseAdapter
     with pytest.raises(ValueError):
         database.quote_relation_name("my-db.my-schema.my-table")


### PR DESCRIPTION
## About
Just a bit of refactoring and infrastructure improvements.

## Details
By making the canonical `DatabaseAdapter.quote_relation_name` static,  it can be used by `TableAddress.fullname` now.
This makes table name quoting less fragmented across the code base.

## References
- https://github.com/crate/cratedb-toolkit/pull/196#discussion_r1684982717

## Notes
We need it for GH-196, and we need to ship it. Please add your voice retroactively, so we can consider any admonitions from your pen even after this has been merged already. Thank you!
