### PR TITLE
Dependencies: Downgrade to `kaggle==1.6.14`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 ## Unreleased
 - `ctk load table`: Added support for MongoDB Change Streams
+- Fix dependency with the `kaggle` package, downgrade to `kaggle==1.6.14`
 
 ## 2024/07/08 v0.0.15
 - IO: Added the `if-exists` query parameter by updating to influxio 0.4.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ cloud = [
 ]
 datasets = [
   "datasets<3",
-  "kaggle<2",
+  "kaggle==1.6.14",
 ]
 develop = [
   "black[jupyter]<25",


### PR DESCRIPTION
## Problem
- CI trips on GH-205.

## Reason
- https://github.com/Kaggle/kaggle-api/issues/611

## Solution
Fix dependency with the `kaggle` package, downgrade to `kaggle==1.6.14`.

## Details
```
The most likely cause of this is that there is no directory that matches the name of your project (kaggle).
```
Most probably, this is coming from switching to Hatch?
