### PR TITLE
CI: Update to Docker Compose V2

### DIFF
--- a/.github/workflows/release-oci.yml
+++ b/.github/workflows/release-oci.yml
@@ -56,8 +56,8 @@ jobs:
           if [[ -f release/oci/test.yml ]]; then
             export DOCKER_BUILDKIT=1
             export COMPOSE_DOCKER_CLI_BUILD=1
-            docker-compose --file release/oci/test.yml build
-            docker-compose --file release/oci/test.yml run sut
+            docker compose --file release/oci/test.yml build
+            docker compose --file release/oci/test.yml run sut
           fi
 
   build-and-publish:

--- a/release/oci/test.yml
+++ b/release/oci/test.yml
@@ -1,4 +1,6 @@
-sut:
-  build: ../..
-  dockerfile: release/oci/Dockerfile
-  command: selftest.sh
+services:
+  sut:
+    build:
+      context: ../..
+      dockerfile: release/oci/Dockerfile
+    command: selftest.sh


### PR DESCRIPTION
## Problem
```
docker-compose: command not found
```
Apparently, GHA phased out the Docker Compose v1 CLI.

## References
- GH-211
- GH-212
- https://github.com/daq-tools/influxio/pull/136
- https://github.com/daq-tools/skeem/pull/82
