### PR TITLE
Chore: Fix reference to LorryStream WIP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ io = [
   "sqlalchemy>=2",
 ]
 kinesis = [
-  "lorrystream @ git+https://github.com/daq-tools/lorrystream.git@55cf456fdcd3",
+  "lorrystream @ git+https://github.com/daq-tools/lorrystream.git@kinesis",
 ]
 mongodb = [
   "commons-codec[mongodb,zyp]==0.0.4",


### PR DESCRIPTION
## Problem

Installation fails with:
```
Running command git clone --filter=blob:none --quiet https://github.com/daq-tools/lorrystream.git 'C:\Users\Hernan\AppData\Local\Temp\pip-install-qb60dek8\lorrystream_4805b8717a3c400e8e6fb2eb16e6e0bd'
  WARNING: Did not find branch or tag '55cf456fdcd3', assuming revision or ref.
```
Then branched cratedb-toolkit and tried making it point to different points in the lorrystream tree (the kinesis branch - the beginning of the kinesis branch - the main branch at the point of toolkit 0.0.16 release) the main branch does not know about carabas, the other 2 also failed with different errors.

Thanks for reporting, @hlcianfagna!