### PR TITLE
MongoDB: Improve type mapper discriminating between INTEGER and BIGINT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 ## Unreleased
 - Dependencies: Unpin commons-codec, to always use the latest version
 - Dependencies: Unpin lorrystream, to always use the latest version
+- MongoDB: Improve type mapper by discriminating between
+  `INTEGER` and `BIGINT`
 
 ## 2024/08/19 v0.0.17
 - Processor: Updated Kinesis Lambda processor to understand AWS DMS

--- a/cratedb_toolkit/io/mongodb/extract.py
+++ b/cratedb_toolkit/io/mongodb/extract.py
@@ -182,5 +182,17 @@ TYPES_MAP = {
 }
 
 
-def get_type(o):
-    return TYPES_MAP.get(type(o), "UNKNOWN")
+def get_type(value):
+    """
+    Resolve value type via type map, with special treatment for integer types.
+
+    INTEGER: -2^31 to 2^31-1
+    BIGINT: -2^63 to 2^63-1
+    """
+    type_ = type(value)
+    if type_ is int:
+        if -(2**31) <= value <= 2**31 - 1:
+            return "INTEGER"
+        else:
+            return "BIGINT"
+    return TYPES_MAP.get(type_, "UNKNOWN")

--- a/tests/io/mongodb/test_extract.py
+++ b/tests/io/mongodb/test_extract.py
@@ -23,6 +23,21 @@ class TestExtractTypes(unittest.TestCase):
         schema = trim_schema(extract.extract_schema_from_document(data, {}))
         self.assertDictEqual(schema, expected)
 
+    def test_integer_types(self):
+        """
+        Validate extraction of numeric types INTEGER vs. BIGINT.
+        """
+        data = {
+            "integer": 2147483647,
+            "bigint": 1563051934000,
+        }
+        expected = {
+            "integer": "INTEGER",
+            "bigint": "BIGINT",
+        }
+        schema = trim_schema(extract.extract_schema_from_document(data, {}))
+        self.assertDictEqual(schema, expected)
+
     def test_bson_types(self):
         data = {
             "a": bson.ObjectId("55153a8014829a865bbf700d"),


### PR DESCRIPTION
## About
@matkuliak reported that the MongoDB I/O subsystem wasn't capable to map values like `Long('1563051934000')` to CrateDB SQL's `BIGINT` data type.

- GH-219

This patch improves the situation.
