### PR TITLE
MongoDB: Improve type mapper in schema translator

### DIFF
--- a/cratedb_toolkit/io/mongodb/extract.py
+++ b/cratedb_toolkit/io/mongodb/extract.py
@@ -171,7 +171,7 @@ TYPES_MAP = {
     bson.datetime.datetime: "DATETIME",
     bson.Timestamp: "TIMESTAMP",
     bson.DatetimeMS: "TIMESTAMP",
-    bson.Decimal128: "DOUBLE",
+    bson.Decimal128: "DECIMAL",
     bson.Int64: "INT64",
     # primitive types
     str: "STRING",
@@ -196,5 +196,5 @@ def get_type(value):
         if -(2**31) <= value <= 2**31 - 1:
             return "INTEGER"
         else:
-            return "BIGINT"
+            return "INT64"
     return TYPES_MAP.get(type_, "UNKNOWN")

--- a/cratedb_toolkit/io/mongodb/translate.py
+++ b/cratedb_toolkit/io/mongodb/translate.py
@@ -38,11 +38,13 @@ from cratedb_toolkit.io.mongodb.util import sanitize_field_names
 TYPES = {
     "OID": "TEXT",
     "DATETIME": "TIMESTAMP WITH TIME ZONE",
-    "INT64": "INTEGER",
+    "TIMESTAMP": "TIMESTAMP WITHOUT TIME ZONE",
+    "INT64": "BIGINT",
     "STRING": "TEXT",
     "BOOLEAN": "BOOLEAN",
     "INTEGER": "INTEGER",
     "FLOAT": "FLOAT",
+    "DECIMAL": "DOUBLE",
     "ARRAY": "ARRAY",
     "OBJECT": "OBJECT",
 }

--- a/tests/io/mongodb/test_extract.py
+++ b/tests/io/mongodb/test_extract.py
@@ -33,7 +33,7 @@ class TestExtractTypes(unittest.TestCase):
         }
         expected = {
             "integer": "INTEGER",
-            "bigint": "BIGINT",
+            "bigint": "INT64",
         }
         schema = trim_schema(extract.extract_schema_from_document(data, {}))
         self.assertDictEqual(schema, expected)
@@ -50,7 +50,7 @@ class TestExtractTypes(unittest.TestCase):
         expected = {
             "datetime": "DATETIME",
             "datetimems": "TIMESTAMP",
-            "decimal128": "DOUBLE",
+            "decimal128": "DECIMAL",
             "int64": "INT64",
             "objectid": "OID",
             "timestamp": "TIMESTAMP",

--- a/tests/io/mongodb/test_translate.py
+++ b/tests/io/mongodb/test_translate.py
@@ -11,7 +11,7 @@ class TestTranslate(unittest.TestCase):
     def test_types_translation(self):
         i = [
             ("DATETIME", "TIMESTAMP WITH TIME ZONE"),
-            ("INT64", "INTEGER"),
+            ("INT64", "BIGINT"),
             ("STRING", "TEXT"),
             ("BOOLEAN", "BOOLEAN"),
             ("INTEGER", "INTEGER"),


### PR DESCRIPTION
The MongoDB type mapper now honors more types.
- DECIMAL => DOUBLE
- INT64 => BIGINT
- TIMESTAMP => TIMESTAMP WITHOUT TIME ZONE
