### PR TITLE
Dependencies: Unpin commons-codec, to always use the latest version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Dependencies: Unpin commons-codec, to always use the latest version
 
 ## 2024/08/19 v0.0.17
 - Processor: Updated Kinesis Lambda processor to understand AWS DMS

--- a/cratedb_toolkit/io/processor/kinesis_lambda.py
+++ b/cratedb_toolkit/io/processor/kinesis_lambda.py
@@ -25,7 +25,7 @@ Resources:
 # /// script
 # requires-python = ">=3.9"
 # dependencies = [
-#   "commons-codec==0.0.7",
+#   "commons-codec",
 #   "sqlalchemy-cratedb==0.38.0",
 # ]
 # ///

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ kinesis = [
   "lorrystream[carabas]==0.0.4",
 ]
 mongodb = [
-  "commons-codec[mongodb,zyp]==0.0.7",
+  "commons-codec[mongodb,zyp]",
   "cratedb-toolkit[io]",
   "orjson<4,>=3.3.1",
   "pymongo<5,>=3.10.1",


### PR DESCRIPTION
What the title says.