### PR TITLE
Dependencies: Unpin lorrystream, to always use the latest version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 ## Unreleased
 - Dependencies: Unpin commons-codec, to always use the latest version
+- Dependencies: Unpin lorrystream, to always use the latest version
 
 ## 2024/08/19 v0.0.17
 - Processor: Updated Kinesis Lambda processor to understand AWS DMS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ io = [
   "sqlalchemy>=2",
 ]
 kinesis = [
-  "lorrystream[carabas]==0.0.4",
+  "lorrystream[carabas]",
 ]
 mongodb = [
   "commons-codec[mongodb,zyp]",


### PR DESCRIPTION
What the title says.