### PR TITLE
DMS/DynamoDB: Fix table name quoting within CDC processor handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- DMS/DynamoDB: Fix table name quoting within CDC processor handler
 
 ## 2024/08/26 v0.0.19
 - MongoDB: Fix and verify Zyp transformations

--- a/cratedb_toolkit/io/processor/kinesis_lambda.py
+++ b/cratedb_toolkit/io/processor/kinesis_lambda.py
@@ -127,8 +127,7 @@ def handler(event, context):
             connection.execute(sa.text(operation.statement), parameters=operation.parameters)
 
             # Processing alternating CDC events requires write synchronization.
-            # FIXME: Needs proper table name quoting.
-            connection.execute(sa.text(f"REFRESH TABLE {CRATEDB_TABLE}"))
+            connection.execute(sa.text(f"REFRESH TABLE {cdc.quote_table_name(CRATEDB_TABLE)}"))
 
             connection.commit()
 


### PR DESCRIPTION
## About
Easily fix missing table quoting within CDC processor for DMS and DynamoDB events. It will need more improvements by adding the canonical implementation [quote_relation_name](https://github.com/crate/cratedb-toolkit/blob/v0.0.19/cratedb_toolkit/util/database.py#L44-L80) to sqlalchemy-cratedb, but may be good for now.
