### PR TITLE
Revert "CI: Codecov API is currently down"

### DIFF
--- a/.github/workflows/influxdb.yml
+++ b/.github/workflows/influxdb.yml
@@ -91,4 +91,4 @@ jobs:
         flags: influxdb
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
         flags: main
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true
 
 
   tests-pymongo:
@@ -154,7 +154,7 @@ jobs:
         flags: pymongo
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true
 
 
   tests-kinesis:
@@ -219,4 +219,4 @@ jobs:
         flags: kinesis
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -90,4 +90,4 @@ jobs:
         flags: mongodb
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true


### PR DESCRIPTION
Codecov API was down, now it's back up.

This reverts commit 12a624f87f411dd1b1206d3b3ce5293d3be9360a.
