### PR TITLE
MongoDB: Improve support for reading JSON/BSON files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ## Unreleased
 - MongoDB: Unlock processing multiple collections, either from server database,
   or from filesystem directory
+- MongoDB: Unlock processing JSON files from HTTP resource, using `https+bson://`
 
 ## 2024/09/10 v0.0.22
 - MongoDB: Rename columns with leading underscores to use double leading underscores

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 
 ## Unreleased
+- MongoDB: Unlock processing multiple collections, either from server database,
+  or from filesystem directory
 
 ## 2024/09/10 v0.0.22
 - MongoDB: Rename columns with leading underscores to use double leading underscores
@@ -14,7 +16,7 @@
   This means relevant column definitions will not be included into the SQL DDL.
 - MongoDB: Make `ctk load table` use the `data OBJECT(DYNAMIC)` mapping strategy.
 - MongoDB: Sanitize lists of varying objects
-- MongoDB: Add `--treatment` option for applying special treatments to certain items
+- MongoDB: Add treatment option for applying special treatments to certain items
   on real-world data
 - MongoDB: Use pagination on source collection, for creating batches towards CrateDB
 - MongoDB: Unlock importing MongoDB Extended JSON files using `file+bson://...`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - MongoDB: Unlock processing multiple collections, either from server database,
   or from filesystem directory
 - MongoDB: Unlock processing JSON files from HTTP resource, using `https+bson://`
+- MongoDB: Optionally filter server collection using MongoDB query expression
 
 ## 2024/09/10 v0.0.22
 - MongoDB: Rename columns with leading underscores to use double leading underscores

--- a/cratedb_toolkit/api/main.py
+++ b/cratedb_toolkit/api/main.py
@@ -133,6 +133,15 @@ class StandaloneCluster(ClusterBase):
                     progress=True,
                 )
 
+        elif source_url_obj.scheme.startswith("http"):
+            if "+bson" in source_url_obj.scheme or "+mongodb" in source_url_obj.scheme:
+                mongodb_copy_generic(
+                    str(source_url_obj),
+                    target_url,
+                    transformation=transformation,
+                    progress=True,
+                )
+
         elif source_url_obj.scheme.startswith("influxdb"):
             from cratedb_toolkit.io.influxdb import influxdb_copy
 

--- a/cratedb_toolkit/io/cli.py
+++ b/cratedb_toolkit/io/cli.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from pathlib import Path
 
 import click
@@ -85,4 +86,5 @@ def load_table(
         cluster = StandaloneCluster(address=address)
     else:
         raise NotImplementedError("Unable to select backend")
-    return cluster.load_table(resource=resource, target=target, transformation=transformation)
+    if not cluster.load_table(resource=resource, target=target, transformation=transformation):
+        sys.exit(2)

--- a/cratedb_toolkit/io/mongodb/adapter.py
+++ b/cratedb_toolkit/io/mongodb/adapter.py
@@ -53,7 +53,7 @@ class MongoDBAdapterBase:
 
     @cached_property
     def batch_size(self) -> int:
-        return int(self.address.uri.query_params.get("batch-size", 500))
+        return int(self.address.uri.query_params.get("batch-size", 100))
 
     @cached_property
     def filter(self) -> t.Union[str, None]:

--- a/cratedb_toolkit/io/mongodb/adapter.py
+++ b/cratedb_toolkit/io/mongodb/adapter.py
@@ -92,7 +92,7 @@ class MongoDBFilesystemAdapter(MongoDBAdapterBase):
         self._path = Path(self.address.uri.path)
 
     def get_collections(self) -> t.List[str]:
-        return list(glob.glob(str(self._path)))
+        return sorted(glob.glob(str(self._path)))
 
     def record_count(self, filter_=None) -> int:
         """
@@ -167,7 +167,7 @@ class MongoDBServerAdapter(MongoDBAdapterBase):
 
     def get_collections(self) -> t.List[str]:
         database = self._mongodb_client.get_database(self.database_name)
-        return database.list_collection_names()
+        return sorted(database.list_collection_names())
 
     def record_count(self, filter_=None) -> int:
         filter_ = filter_ or {}

--- a/cratedb_toolkit/io/mongodb/api.py
+++ b/cratedb_toolkit/io/mongodb/api.py
@@ -130,6 +130,8 @@ def mongodb_copy(source_url, target_url, transformation: t.Union[Path, None] = N
         logger.info(f"Inquiring collections at {source_url}")
         mongodb_uri = URL(source_url)
         cratedb_uri = URL(target_url)
+        if Path(mongodb_uri.path).is_absolute() and mongodb_uri.path[-1] != "/":
+            mongodb_uri.path += "/"
         if cratedb_uri.path[-1] != "/":
             cratedb_uri.path += "/"
         mongodb_query_parameters = mongodb_uri.query_params

--- a/cratedb_toolkit/io/mongodb/copy.py
+++ b/cratedb_toolkit/io/mongodb/copy.py
@@ -144,11 +144,14 @@ class MongoDBFullLoad:
                     result = connection.execute(sa.text(operation.statement), operation.parameters)
                     result_size = result.rowcount
                     if result_size < 0:
-                        raise ValueError("Unable to insert one or more records")
+                        raise IOError("Unable to insert one or more records")
                     records_out += result_size
                     progress_bar.update(n=result_size)
                 except Exception as ex:
-                    logger_on_error(f"Executing operation failed: {ex}\nOperation:\n{operation}")
+                    logger_on_error(
+                        f"Executing operation failed: {ex}\n"
+                        f"Statement: {operation.statement}\nParameters: {str(operation.parameters)[:500]} [...]"
+                    )
                     if self.on_error == "raise":
                         raise
                     continue

--- a/cratedb_toolkit/io/mongodb/copy.py
+++ b/cratedb_toolkit/io/mongodb/copy.py
@@ -69,8 +69,8 @@ class MongoDBFullLoad:
 
     def __init__(
         self,
-        mongodb_url: str,
-        cratedb_url: str,
+        mongodb_url: t.Union[str, URL],
+        cratedb_url: t.Union[str, URL],
         tm: t.Union[TransformationManager, None],
         on_error: t.Literal["ignore", "raise"] = "raise",
         progress: bool = False,
@@ -83,7 +83,7 @@ class MongoDBFullLoad:
         self.mongodb_adapter = mongodb_adapter_factory(self.mongodb_uri)
 
         # Decode database URL: CrateDB.
-        self.cratedb_address = DatabaseAddress.from_string(cratedb_url)
+        self.cratedb_address = DatabaseAddress(self.cratedb_uri)
         self.cratedb_sqlalchemy_url, self.cratedb_table_address = self.cratedb_address.decode()
         cratedb_table = self.cratedb_table_address.fullname
 

--- a/cratedb_toolkit/model.py
+++ b/cratedb_toolkit/model.py
@@ -144,8 +144,8 @@ class AddressPair:
         source_url_query_parameters = self.source_url.query_params
         target_url_query_parameters = self.target_url.query_params
 
-        source_url = URL(str(self.source_url))
-        target_url = URL(str(self.target_url))
+        source_url = deepcopy(self.source_url)
+        target_url = deepcopy(self.target_url)
 
         # Q: What the hack?
         # A: It makes subsequent `.navigate()` operations work.

--- a/cratedb_toolkit/util/database.py
+++ b/cratedb_toolkit/util/database.py
@@ -403,7 +403,7 @@ def decode_database_table(url: str) -> t.Tuple[str, t.Union[str, None]]:
             if url_.scheme == "crate" and not database:
                 database = url_.query_params.get("schema")
             if database is None and table is None:
-                if url_.scheme.startswith("file"):
+                if url_.scheme.startswith("file") or url_.scheme.startswith("http"):
                     _, database, table = url_.path.rsplit("/", 2)
 
                     # If table name is coming from a filesystem, strip suffix, e.g. `books-relaxed.ndjson`.

--- a/doc/io/mongodb/loader.md
+++ b/doc/io/mongodb/loader.md
@@ -91,15 +91,23 @@ The default batch size is 500. You can adjust the value by appending the HTTP
 URL query parameter `batch-size` to the source URL, like
 `mongodb+srv://managed.mongodb.net/ticker/stocks?batch-size=5000`.
 
-### Offset
-Use the HTTP URL query parameter `offset` on the source URL, like
-`&offset=42`, in order to start processing at this record from the
-beginning.
+### Filter
+Use the HTTP URL query parameter `filter` on the source URL, like
+`&filter={"exchange": {"$eq": "NASDAQ"}}`, in order to provide a MongoDB
+query filter as a JSON string.
+It works in the same way like `mongoexport`'s `--query` option.
+On more complex query expressions, make sure to properly encode the right
+value using URL/Percent Encoding.
 
 ### Limit
 Use the HTTP URL query parameter `limit` on the source URL, like
 `&limit=100`, in order to limit processing to a total number of
 records.
+
+### Offset
+Use the HTTP URL query parameter `offset` on the source URL, like
+`&offset=42`, in order to start processing at this record from the
+beginning.
 
 ## Zyp Transformations
 You can use [Zyp Transformations] to change the shape of the data while being

--- a/doc/io/mongodb/loader.md
+++ b/doc/io/mongodb/loader.md
@@ -87,8 +87,9 @@ see [](#file-import-tutorial).
 ## Options
 
 ### Batch Size
-The default batch size is 500. You can adjust the value by appending the HTTP
-URL query parameter `batch-size` to the source URL, like
+The default batch size is 100, but for many datasets a much larger batch size
+is applicable for most efficient data transfers. You can adjust the value by
+appending the HTTP URL query parameter `batch-size` to the source URL, like
 `mongodb+srv://managed.mongodb.net/ticker/stocks?batch-size=5000`.
 
 ### Filter

--- a/doc/io/mongodb/loader.md
+++ b/doc/io/mongodb/loader.md
@@ -22,6 +22,10 @@ server instances and filesystems.
 
   Read files in [MongoDB Extended JSON] or [BSON] format from filesystem.
 
+- `http+bson://`
+
+  Read files in [MongoDB Extended JSON] or [BSON] format from HTTP resource.
+
 ## Install
 ```shell
 pip install --upgrade 'cratedb-toolkit[mongodb]'
@@ -63,13 +67,16 @@ Load data from MongoDB JSON/BSON files, for example produced by the
 `mongoexport` or `mongodump` programs.
 
 ```shell
-# Extended JSON, full path.
+# Extended JSON, filesystem, full path.
 ctk load table "file+bson:///path/to/mongodb-json-files/datasets/books.json"
 
-# Extended JSON, multiple files.
+# Extended JSON, HTTP resource.
+ctk load table "https+bson://github.com/ozlerhakan/mongodb-json-files/raw/master/datasets/books.json"
+
+# Extended JSON, filesystem, multiple files.
 ctk load table "file+bson:///path/to/mongodb-json-files/datasets/*.json"
 
-# BSON, compressed, relative path.
+# BSON, filesystem, relative path, compressed.
 ctk load table "file+bson:./var/data/testdrive/books.bson.gz"
 ```
 

--- a/tests/io/mongodb/test_copy.py
+++ b/tests/io/mongodb/test_copy.py
@@ -1,3 +1,7 @@
+from copy import deepcopy
+from unittest import mock
+
+import pymongo
 import pytest
 
 from cratedb_toolkit.io.mongodb.api import mongodb_copy
@@ -12,6 +16,70 @@ def check_prerequisites():
     This subsystem needs SQLAlchemy 2.x.
     """
     check_sqlalchemy2()
+
+
+def test_mongodb_copy_server_database(caplog, cratedb, mongodb):
+    """
+    Verify MongoDB -> CrateDB data transfer for all collections in a database.
+    """
+
+    # Define source and target URLs.
+    mongodb_url = f"{mongodb.get_connection_url()}/testdrive"
+    cratedb_url = f"{cratedb.get_connection_url()}/testdrive"
+
+    # Define data.
+    data_in = {"device": "Hotzenplotz", "temperature": 42.42, "timestamp": 1563051934000}
+    data_out = deepcopy(data_in)
+    data_out.update({"_id": mock.ANY})
+
+    # Populate source database.
+    client: pymongo.MongoClient = mongodb.get_connection_client()
+    testdrive = client.get_database("testdrive")
+    demo1 = testdrive.create_collection("demo1")
+    demo1.insert_one(data_in)
+    demo2 = testdrive.create_collection("demo2")
+    demo2.insert_one(data_in)
+
+    # Run transfer command.
+    mongodb_copy(
+        mongodb_url,
+        cratedb_url,
+    )
+
+    # Verify data in target database.
+    cratedb.database.refresh_table("testdrive.demo1")
+    cratedb.database.refresh_table("testdrive.demo2")
+    results = cratedb.database.run_sql("SELECT * FROM testdrive.demo1;", records=True)
+    assert results[0]["data"] == data_out
+    results = cratedb.database.run_sql("SELECT * FROM testdrive.demo2;", records=True)
+    assert results[0]["data"] == data_out
+
+
+def test_mongodb_copy_filesystem_folder(caplog, cratedb, mongodb):
+    """
+    Verify MongoDB -> CrateDB data transfer for all files in a folder.
+    """
+
+    # Reset two database tables.
+    cratedb.database.run_sql('DROP TABLE IF EXISTS testdrive."books-canonical";')
+    cratedb.database.run_sql('DROP TABLE IF EXISTS testdrive."books-relaxed";')
+
+    # Define source and target URLs.
+    fs_resource = "file+bson:./tests/io/mongodb/*.ndjson"
+    cratedb_url = f"{cratedb.get_connection_url()}/testdrive"
+
+    # Run transfer command.
+    mongodb_copy(
+        fs_resource,
+        cratedb_url,
+    )
+
+    # Verify data in target database.
+    cratedb.database.refresh_table("testdrive.books-canonical")
+    cratedb.database.refresh_table("testdrive.books-relaxed")
+
+    assert cratedb.database.count_records("testdrive.books-canonical") == 4
+    assert cratedb.database.count_records("testdrive.books-relaxed") == 4
 
 
 def test_mongodb_copy_filesystem_json_relaxed(caplog, cratedb):


### PR DESCRIPTION
## About
A few features that have not been ready (lacked software tests) to be included into GH-255.

## Details
- Unlock processing multiple collections, either from server database, or from filesystem directory
- Unlock processing JSON files from HTTP resource, using `https+bson://`
- Optionally filter server collection using MongoDB query expression

## Documentation
https://cratedb-toolkit--261.org.readthedocs.build/io/mongodb/loader.html

## Install
```
pip install --upgrade 'cratedb-toolkit[mongodb] @ git+https://github.com/crate/cratedb-toolkit.git@amo/mongodb-more-2'
```
