### PR TITLE
MongoDB: Configure `MongoDBCrateDBConverter` for updating commons-codec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- MongoDB: Configure `MongoDBCrateDBConverter` after updating to commons-codec 0.0.18
 
 ## 2024/09/22 v0.0.25
 - Table Loader: Improved conditional handling of "transformation" parameter

--- a/cratedb_toolkit/io/mongodb/copy.py
+++ b/cratedb_toolkit/io/mongodb/copy.py
@@ -57,9 +57,14 @@ class MongoDBFullLoad:
             )
             try:
                 transformation = tm.project.get(address=address)
+                logger.info(f"Applying transformation to: {address}")
             except KeyError:
-                pass
-        self.converter = MongoDBCrateDBConverter(transformation=transformation)
+                logger.warning(f"No transformation found for: {address}")
+        self.converter = MongoDBCrateDBConverter(
+            timestamp_to_epoch=True,
+            timestamp_use_milliseconds=True,
+            transformation=transformation,
+        )
         self.translator = MongoDBFullLoadTranslator(table_name=self.cratedb_table, converter=self.converter)
 
         self.on_error = on_error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ mongodb = [
   "commons-codec[mongodb,zyp]>=0.0.18",
   "cratedb-toolkit[io]",
   "orjson<4,>=3.3.1",
-  "pymongo<5,>=3.10.1",
+  "pymongo<4.9,>=3.10.1",
   "python-bsonjs<0.5",
   "rich<14,>=3.3.2",
   "undatum<1.1",
@@ -178,7 +178,7 @@ mongodb = [
 pymongo = [
   "jessiql==1.0.0rc1",
   "pandas==2.1.*",
-  "pymongo==4.8.*",
+  "pymongo<4.9",
   "sqlalchemy<2",
 ]
 release = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ kinesis = [
   "lorrystream[carabas]>=0.0.6",
 ]
 mongodb = [
-  "commons-codec[mongodb,zyp]>=0.0.17",
+  "commons-codec[mongodb,zyp]>=0.0.18",
   "cratedb-toolkit[io]",
   "orjson<4,>=3.3.1",
   "pymongo<5,>=3.10.1",


### PR DESCRIPTION
## About
commons-codec 0.0.18 provides configuration capabilities about how to decode timestamp values. CTK currently uses this configuration, in order to emit timestamp values in milliseconds since epoch, suitable to be stored as BIGINT.
```python
MongoDBCrateDBConverter(
    timestamp_to_epoch=True,
    timestamp_use_milliseconds=True,
)
```

Alternatively, you can configure it to emit timestamps in ISO8601 format, suitable to be stored as STRING.
```python
MongoDBCrateDBConverter(
    timestamp_to_iso8601=True,
)
```

/cc @hlcianfagna, @wierdvanderhaar 