### PR TITLE
DynamoDB: Change CrateDB data model to use (`pk`, `data`, `aux`) columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 - MongoDB: Updated to pymongo 4.9
+- DynamoDB: Change CrateDB data model to use (`pk`, `data`, `aux`) columns
+  Attention: This is a breaking change.
 
 ## 2024/09/26 v0.0.26
 - MongoDB: Configure `MongoDBCrateDBConverter` after updating to commons-codec 0.0.18

--- a/cratedb_toolkit/io/dynamodb/adapter.py
+++ b/cratedb_toolkit/io/dynamodb/adapter.py
@@ -2,6 +2,7 @@ import logging
 import typing as t
 
 import boto3
+from commons_codec.transform.dynamodb_model import PrimaryKeySchema
 from yarl import URL
 
 logger = logging.getLogger(__name__)
@@ -55,3 +56,18 @@ class DynamoDBAdapter:
     def count_records(self, table_name: str):
         table = self.dynamodb_resource.Table(table_name)
         return table.item_count
+
+    def primary_key_schema(self, table_name: str) -> PrimaryKeySchema:
+        """
+        Return primary key information for given table, derived from `KeySchema` [1] and `AttributeDefinition` [2].
+
+        AttributeType:
+        - S - the attribute is of type String
+        - N - the attribute is of type Number
+        - B - the attribute is of type Binary
+
+        [1] https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html#DDB-CreateTable-request-KeySchema
+        [2] https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeDefinition.html
+        """
+        table = self.dynamodb_resource.Table(table_name)
+        return PrimaryKeySchema.from_table(table)

--- a/cratedb_toolkit/io/processor/kinesis_lambda.py
+++ b/cratedb_toolkit/io/processor/kinesis_lambda.py
@@ -25,7 +25,7 @@ Resources:
 # /// script
 # requires-python = ">=3.9"
 # dependencies = [
-#   "commons-codec>=0.0.19",
+#   "commons-codec>=0.0.20",
 #   "sqlalchemy-cratedb==0.38.0",
 # ]
 # ///

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ docs = [
 ]
 dynamodb = [
   "boto3",
-  "commons-codec>=0.0.19",
+  "commons-codec>=0.0.20",
 ]
 full = [
   "cratedb-toolkit[cfr,cloud,datasets,io,service]",
@@ -163,11 +163,11 @@ io = [
 kinesis = [
   "aiobotocore<2.16",
   "async-kinesis<1.2",
-  "commons-codec>=0.0.19",
+  "commons-codec>=0.0.20",
   "lorrystream[carabas]>=0.0.6",
 ]
 mongodb = [
-  "commons-codec[mongodb,zyp]>=0.0.19",
+  "commons-codec[mongodb,zyp]>=0.0.20",
   "cratedb-toolkit[io]",
   "orjson<4,>=3.3.1",
   "pymongo<4.10,>=3.10.1",

--- a/tests/io/dynamodb/test_relay.py
+++ b/tests/io/dynamodb/test_relay.py
@@ -2,6 +2,7 @@ import threading
 import time
 
 import pytest
+from commons_codec.transform.dynamodb_model import PrimaryKeySchema
 
 from cratedb_toolkit.io.kinesis.relay import KinesisRelay
 from tests.io.test_processor import DYNAMODB_CDC_INSERT_NESTED, DYNAMODB_CDC_MODIFY_NESTED, wrap_kinesis
@@ -33,7 +34,8 @@ def test_kinesis_earliest_dynamodb_cdc_insert_update(caplog, cratedb, dynamodb):
     table_name = '"testdrive"."demo"'
 
     # Create target table.
-    cratedb.database.run_sql(DynamoDBCDCTranslator(table_name=table_name).sql_ddl)
+    translator = DynamoDBCDCTranslator(table_name=table_name, primary_key_schema=PrimaryKeySchema().add("id", "S"))
+    cratedb.database.run_sql(translator.sql_ddl)
 
     # Define two CDC events: INSERT and UPDATE.
     events = [
@@ -76,7 +78,8 @@ def test_kinesis_latest_dynamodb_cdc_insert_update(caplog, cratedb, dynamodb):
     table_name = '"testdrive"."demo"'
 
     # Create target table.
-    cratedb.database.run_sql(DynamoDBCDCTranslator(table_name=table_name).sql_ddl)
+    translator = DynamoDBCDCTranslator(table_name=table_name, primary_key_schema=PrimaryKeySchema().add("id", "S"))
+    cratedb.database.run_sql(translator.sql_ddl)
 
     # Define two CDC events: INSERT and UPDATE.
     events = [

--- a/tests/io/test_processor.py
+++ b/tests/io/test_processor.py
@@ -10,6 +10,7 @@ pytestmark = pytest.mark.kinesis
 pytest.importorskip("commons_codec", reason="Only works with commons-codec installed")
 
 from commons_codec.transform.dynamodb import DynamoDBCDCTranslator  # noqa: E402
+from commons_codec.transform.dynamodb_model import PrimaryKeySchema  # noqa: E402
 
 DYNAMODB_CDC_INSERT_NESTED = {
     "awsRegion": "us-east-1",
@@ -122,7 +123,8 @@ def test_processor_kinesis_dynamodb_insert_update(cratedb, reset_handler, mocker
     table_name = '"testdrive"."demo"'
 
     # Create target table.
-    cratedb.database.run_sql(DynamoDBCDCTranslator(table_name=table_name).sql_ddl)
+    translator = DynamoDBCDCTranslator(table_name=table_name, primary_key_schema=PrimaryKeySchema().add("id", "S"))
+    cratedb.database.run_sql(translator.sql_ddl)
 
     # Configure Lambda processor per environment variables.
     handler_environment = {


### PR DESCRIPTION
## About
By breaking the primary key information out of the main record's data bucket, the main record can be updated as-is on CDC MODIFY operations.

## References
- https://github.com/crate/commons-codec/pull/64