### PR TITLE
Testcontainers: Don't always pull the OCI image before starting.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   also checking `rowcount` for handling `INSERT OK, 0 rows` responses
 - MongoDB: Fixed BSON decoding of `{"$date": 1180690093000}` timestamps
   by updating to commons-codec 0.0.21.
+- Testcontainers: Don't always pull the OCI image before starting.
+  It is unfortunate in disconnected situations.
 
 ## 2024/10/01 v0.0.27
 - MongoDB: Updated to pymongo 4.9

--- a/cratedb_toolkit/testing/testcontainers/util.py
+++ b/cratedb_toolkit/testing/testcontainers/util.py
@@ -87,8 +87,9 @@ class KeepaliveContainer(DockerContainer):
         containers = docker_client.client.api.containers(all=True, filters={"name": self._name})
 
         if not containers:
-            logger.info(f"Pulling image: {self.image}")
-            docker_client.client.images.pull(self.image)
+            if asbool(self._kwargs.get("pull", False)):
+                logger.info(f"Pulling image: {self.image}")
+                docker_client.client.images.pull(self.image)
             logger.info(f"Creating container from image: {self.image}")
             self._container = docker_client.run(
                 self.image,


### PR DESCRIPTION
## About
Pulling the OCI each time again is unfortunate in disconnected situations. Let's stop doing it.
