### PR TITLE
MongoDB: Add Zyp transformations to CDC subsystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- MongoDB: Added Zyp transformations to the CDC subsystem,
+  making it more symmetric to the full-load procedure.
 
 ## 2024/10/09 v0.0.28
 - IO: Improved `BulkProcessor` when running per-record operations by

--- a/cratedb_toolkit/api/main.py
+++ b/cratedb_toolkit/api/main.py
@@ -156,7 +156,11 @@ class StandaloneCluster(ClusterBase):
 
                 from cratedb_toolkit.io.mongodb.api import mongodb_relay_cdc
 
-                return mongodb_relay_cdc(str(source_url_obj), target_url, progress=True)
+                return mongodb_relay_cdc(
+                    source_url_obj,
+                    target_url,
+                    transformation=transformation,
+                )
             else:
                 from cratedb_toolkit.io.mongodb.api import mongodb_copy
 

--- a/cratedb_toolkit/io/mongodb/adapter.py
+++ b/cratedb_toolkit/io/mongodb/adapter.py
@@ -86,6 +86,10 @@ class MongoDBAdapterBase:
     def query(self):
         raise NotImplementedError()
 
+    @abstractmethod
+    def subscribe(self):
+        raise NotImplementedError()
+
 
 @define
 class MongoDBFilesystemAdapter(MongoDBAdapterBase):
@@ -122,6 +126,9 @@ class MongoDBFilesystemAdapter(MongoDBAdapterBase):
             raise ValueError(f"Unsupported file type: {self._path.suffix}")
         return batches(data, self.batch_size)
 
+    def subscribe(self):
+        raise NotImplementedError("Subscribing to a change stream is not supported by filesystem adapter")
+
 
 @define
 class MongoDBResourceAdapter(MongoDBAdapterBase):
@@ -152,6 +159,9 @@ class MongoDBResourceAdapter(MongoDBAdapterBase):
         else:
             raise ValueError(f"Unsupported file type: {self._url}")
         return batches(data, self.batch_size)
+
+    def subscribe(self):
+        raise NotImplementedError("HTTP+BSON loader does not support subscribing to a change stream")
 
 
 @define
@@ -192,6 +202,9 @@ class MongoDBServerAdapter(MongoDBAdapterBase):
             .limit(self.limit)
         )
         return batches(data, self.batch_size)
+
+    def subscribe(self):
+        return self._mongodb_collection.watch(full_document="updateLookup")
 
 
 def mongodb_adapter_factory(mongodb_uri: URL) -> MongoDBAdapterBase:

--- a/cratedb_toolkit/io/mongodb/api.py
+++ b/cratedb_toolkit/io/mongodb/api.py
@@ -145,7 +145,7 @@ def mongodb_copy(
         address_pair_root = AddressPair(source_url=source_url, target_url=target_url)
 
         mongodb_adapter = mongodb_adapter_factory(address_pair_root.source_url)
-        collections = mongodb_adapter.get_collections()
+        collections = mongodb_adapter.get_collection_names()
         logger.info(f"Discovered collections: {len(collections)}")
         logger.debug(f"Processing collections: {collections}")
 

--- a/cratedb_toolkit/io/mongodb/cdc.py
+++ b/cratedb_toolkit/io/mongodb/cdc.py
@@ -8,11 +8,16 @@ Documentation:
 """
 
 import logging
+import typing as t
 
-import pymongo
 import sqlalchemy as sa
-from commons_codec.transform.mongodb import MongoDBCDCTranslator
+from boltons.urlutils import URL
+from commons_codec.transform.mongodb import MongoDBCDCTranslator, MongoDBCrateDBConverter
+from zyp.model.collection import CollectionAddress
 
+from cratedb_toolkit.io.mongodb.adapter import mongodb_adapter_factory
+from cratedb_toolkit.io.mongodb.transform import TransformationManager
+from cratedb_toolkit.model import DatabaseAddress
 from cratedb_toolkit.util import DatabaseAdapter
 
 logger = logging.getLogger(__name__)
@@ -25,17 +30,47 @@ class MongoDBCDCRelayCrateDB:
 
     def __init__(
         self,
-        mongodb_url: str,
-        mongodb_database: str,
-        mongodb_collection: str,
-        cratedb_sqlalchemy_url: str,
-        cratedb_table: str,
+        mongodb_url: t.Union[str, URL],
+        cratedb_url: t.Union[str, URL],
+        tm: t.Union[TransformationManager, None],
+        on_error: t.Literal["ignore", "raise"] = "ignore",
+        debug: bool = True,
     ):
-        self.cratedb_adapter = DatabaseAdapter(cratedb_sqlalchemy_url, echo=True)
-        self.mongodb_client: pymongo.MongoClient = pymongo.MongoClient(mongodb_url)
-        self.mongodb_collection = self.mongodb_client[mongodb_database][mongodb_collection]
-        self.table_name = self.cratedb_adapter.quote_relation_name(cratedb_table)
-        self.cdc = MongoDBCDCTranslator(table_name=self.table_name)
+        self.mongodb_uri = URL(mongodb_url)
+        self.cratedb_uri = URL(cratedb_url)
+
+        # Decode database URL: MongoDB.
+        self.mongodb_adapter = mongodb_adapter_factory(self.mongodb_uri)
+
+        # Decode database URL: CrateDB.
+        self.cratedb_address = DatabaseAddress(self.cratedb_uri)
+        self.cratedb_sqlalchemy_url, self.cratedb_table_address = self.cratedb_address.decode()
+        cratedb_table = self.cratedb_table_address.fullname
+
+        self.cratedb_adapter = DatabaseAdapter(str(self.cratedb_sqlalchemy_url), echo=False)
+        self.cratedb_table = self.cratedb_adapter.quote_relation_name(cratedb_table)
+
+        # Transformation machinery.
+        transformation = None
+        if tm:
+            address = CollectionAddress(
+                container=self.mongodb_adapter.database_name, name=self.mongodb_adapter.collection_name
+            )
+            try:
+                transformation = tm.project.get(address=address)
+                logger.info(f"Applying transformation to: {address}")
+            except KeyError:
+                logger.warning(f"No transformation found for: {address}")
+        self.converter = MongoDBCrateDBConverter(
+            timestamp_to_epoch=True,
+            timestamp_use_milliseconds=True,
+            transformation=transformation,
+        )
+
+        self.cdc = MongoDBCDCTranslator(table_name=self.cratedb_table, converter=self.converter)
+
+        self.on_error = on_error
+        self.debug = debug
 
     def start(self):
         """
@@ -52,10 +87,10 @@ class MongoDBCDCRelayCrateDB:
         """
         Subscribe to change stream events, and emit corresponding SQL statements.
         """
-        # Note that `.watch()` will block until events are ready for consumption, so
-        # this is not a busy loop.
+        # Note that `.subscribe()` (calling `.watch()`) will block until events are ready
+        # for consumption, so this is not a busy loop.
         # FIXME: Note that the function does not perform any sensible error handling yet.
         while True:
-            with self.mongodb_collection.watch(full_document="updateLookup") as change_stream:
+            with self.mongodb_adapter.subscribe() as change_stream:
                 for change in change_stream:
                     yield self.cdc.to_sql(change)

--- a/cratedb_toolkit/testing/testcontainers/mongodb.py
+++ b/cratedb_toolkit/testing/testcontainers/mongodb.py
@@ -11,7 +11,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import os
+import time
+import typing as t
 
+import pymongo.errors
+from pymongo import MongoClient
+from testcontainers.core.exceptions import ContainerStartException
 from testcontainers.mongodb import MongoDbContainer
 
 from cratedb_toolkit.testing.testcontainers.util import KeepaliveContainer
@@ -30,7 +35,10 @@ class MongoDbContainerWithKeepalive(KeepaliveContainer, MongoDbContainer):
     useful when used within a test matrix. Its default value is `latest`.
     """
 
+    NAME = "testcontainers-mongodb-vanilla"
     MONGODB_VERSION = os.environ.get("MONGODB_VERSION", "latest")
+    TIMEOUT = 5000
+    DIRECT_CONNECTION = False
 
     def __init__(
         self,
@@ -38,4 +46,96 @@ class MongoDbContainerWithKeepalive(KeepaliveContainer, MongoDbContainer):
         **kwargs,
     ) -> None:
         super().__init__(image=image, **kwargs)
-        self.with_name("testcontainers-mongodb")
+        self.with_name(self.NAME)
+
+    def get_connection_client(self) -> MongoClient:
+        return MongoClient(
+            self.get_connection_url(),
+            directConnection=self.DIRECT_CONNECTION,
+            socketTimeoutMS=self.TIMEOUT,
+            connectTimeoutMS=self.TIMEOUT,
+            serverSelectionTimeoutMS=self.TIMEOUT,
+        )
+
+
+class MongoDbReplicasetContainer(MongoDbContainerWithKeepalive):
+    """
+    A Testcontainer for MongoDB with transparent replica set configuration.
+
+    Overwritten to nullify MONGO_INITDB_ROOT_USERNAME + _PASSWORD,
+    and username + password, because replicaset + authentication
+    is more complicated to configure.
+    """
+
+    NAME = "testcontainers-mongodb-replicaset"
+    DIRECT_CONNECTION = True
+
+    def _configure(self) -> None:
+        self.with_command("mongod --replSet testcontainers-rs")
+        self.with_env("MONGO_DB", self.dbname)
+
+    def _create_connection_url(
+        self,
+        dialect: str,
+        host: t.Optional[str] = None,
+        port: t.Optional[int] = None,
+        dbname: t.Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        from testcontainers.core.utils import raise_for_deprecated_parameter
+
+        if raise_for_deprecated_parameter(kwargs, "db_name", "dbname"):
+            raise ValueError(f"Unexpected arguments: {','.join(kwargs)}")
+        if self._container is None:
+            raise ContainerStartException("container has not been started")
+        host = host or self.get_container_host_ip()
+        port = self.get_exposed_port(port)
+        url = f"{dialect}://{host}:{port}"
+        if dbname:
+            url = f"{url}/{dbname}"
+        return url
+
+    def get_connection_url(self) -> str:
+        return self._create_connection_url(
+            dialect="mongodb",
+            port=self.port,
+        )
+
+    def _connect(self) -> None:
+        """
+        Connect to MongoDB, and establish replica set.
+
+        https://www.mongodb.com/docs/v5.0/reference/command/replSetInitiate/
+        https://www.mongodb.com/docs/v5.0/reference/method/rs.initiate/#mongodb-method-rs.initiate
+
+        https://www.mongodb.com/docs/v5.0/reference/command/replSetGetStatus/
+        https://www.mongodb.com/docs/v5.0/reference/method/rs.status/#mongodb-method-rs.status
+        """
+        super()._connect()
+
+        rs_config = {"_id": "testcontainers-rs", "members": [{"_id": 0, "host": "localhost:27017"}]}
+
+        client = self.get_connection_client()
+        db = client.get_database("admin")
+        for _ in range(10):
+            response = db.command("ping")
+            if response["ok"]:
+                break
+            time.sleep(0.5)
+
+        try:
+            db.command({"replSetInitiate": rs_config})
+        except pymongo.errors.OperationFailure as ex:
+            if ex.details is None or ex.details["codeName"] != "AlreadyInitialized":
+                raise
+
+        response = db.command({"replSetGetStatus": 1})
+        if not response["myState"]:
+            raise IOError("MongoDB replica set failed")
+
+        for _ in range(10):
+            if client.is_primary:
+                return
+            time.sleep(0.5)
+
+        raise IOError("Unable to spin up MongoDB with replica set")

--- a/cratedb_toolkit/util/process.py
+++ b/cratedb_toolkit/util/process.py
@@ -1,0 +1,23 @@
+import logging
+import time
+import typing as t
+
+logger = logging.getLogger(__name__)
+
+
+class FixedBackoff:
+    def __init__(self, sequence: t.List[int]):
+        self.sequence = sequence
+        self.attempt = 0
+
+    def next(self) -> None:
+        self.attempt += 1
+        if self.attempt < len(self.sequence):
+            delay = self.sequence[self.attempt]
+        else:
+            delay = self.sequence[-1]
+        logger.info(f"Retry attempt #{self.attempt} in {delay} seconds")
+        time.sleep(delay)
+
+    def reset(self) -> None:
+        self.attempt = 0

--- a/doc/io/mongodb/cdc.md
+++ b/doc/io/mongodb/cdc.md
@@ -111,6 +111,12 @@ crash --hosts "${CRATEDB_HTTP_URL}" --command 'SELECT * FROM "testdrive"."demo-c
 ```
 
 
+## Transformations
+You can use [Zyp Transformations] to change the shape of the data while being
+transferred. In order to add it to the pipeline, use the `--transformation`
+command line option.
+
+
 ## Appendix
 A few operations that are handy when exploring this exercise.
 
@@ -154,3 +160,4 @@ mongosh "${MONGODB_URL}" --eval 'db.demo.drop()'
 [MongoDB Atlas]: https://www.mongodb.com/atlas
 [MongoDB Change Stream]: https://www.mongodb.com/docs/manual/changeStreams/
 [SDK and CLI for CrateDB Cloud Cluster APIs]: https://github.com/crate-workbench/cratedb-toolkit/pull/81
+[Zyp Transformations]: https://commons-codec.readthedocs.io/zyp/

--- a/doc/io/mongodb/loader.md
+++ b/doc/io/mongodb/loader.md
@@ -126,7 +126,7 @@ Use the HTTP URL query parameter `offset` on the source URL, like
 `&offset=42`, in order to start processing at this record from the
 beginning.
 
-## Zyp Transformations
+## Transformations
 You can use [Zyp Transformations] to change the shape of the data while being
 transferred. In order to add it to the pipeline, use the `--transformation`
 command line option.
@@ -244,5 +244,5 @@ recent versions like MongoDB 7 and tools version 100.9.5 or higher.
 [libbson test files]: https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson/tests/json
 [MongoDB Extended JSON]: https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/
 [mongodb-json-files]: https://github.com/ozlerhakan/mongodb-json-files
-[Zyp Transformations]: https://commons-codec.readthedocs.io/zyp/index.html
+[Zyp Transformations]: https://commons-codec.readthedocs.io/zyp/
 [zyp-mongodb-json-files.yaml]: https://github.com/crate/cratedb-toolkit/blob/v0.0.22/examples/zyp/zyp-mongodb-json-files.yaml

--- a/tests/io/mongodb/test_cdc.py
+++ b/tests/io/mongodb/test_cdc.py
@@ -1,0 +1,82 @@
+import datetime as dt
+from pathlib import Path
+
+from bson import ObjectId
+
+from cratedb_toolkit.io.mongodb.cdc import MongoDBCDCRelayCrateDB
+from cratedb_toolkit.io.mongodb.transform import TransformationManager
+from tests.util.processor import BackgroundProcessor
+
+DOCUMENT_INSERT = {
+    "_id": ObjectId("669683c2b0750b2c84893f3e"),
+    "id": "5F9E",
+    "data": {"temperature": 42.42, "humidity": 84.84},
+    "tombstone": "foo",
+}
+
+
+DOCUMENT_UPDATE = {
+    "_id": ObjectId("669683c2b0750b2c84893f3e"),
+    "id": "5F9E",
+    "data": {"temperature": 42.5},
+    "new": "foo",
+    "some_date": dt.datetime(2024, 7, 11, 23, 17, 42),
+}
+
+
+def test_mongodb_cdc_insert_update(caplog, mongodb_replicaset, cratedb):
+    """
+    Roughly verify that the MongoDB CDC processing works as expected.
+    """
+
+    # Define source and target URLs.
+    mongodb_url = f"{mongodb_replicaset.get_connection_url()}/testdrive/demo?direct=true"
+    cratedb_url = f"{cratedb.get_connection_url()}/testdrive/demo"
+
+    # Optionally configure transformations.
+    tm = TransformationManager.from_any(Path("examples/zyp/zyp-transformation.yaml"))
+
+    # Initialize table loader.
+    table_loader = MongoDBCDCRelayCrateDB(
+        mongodb_url=mongodb_url,
+        cratedb_url=cratedb_url,
+        tm=tm,
+    )
+
+    # Define target table name.
+    table_name = table_loader.cratedb_table
+
+    # Create source collection.
+    table_loader.mongodb_adapter.create_collection()
+
+    # Create target table.
+    table_loader.cratedb_adapter.run_sql(table_loader.cdc.sql_ddl)
+
+    # Start event processor / stream consumer in separate thread, consuming forever.
+    with BackgroundProcessor(loader=table_loader, cratedb=cratedb) as processor:
+        # Populate source database with data.
+        processor.loader.mongodb_adapter.collection.insert_one(DOCUMENT_INSERT)
+        next(processor)
+
+        processor.loader.mongodb_adapter.collection.replace_one(
+            filter={"_id": DOCUMENT_UPDATE["_id"]}, replacement=DOCUMENT_UPDATE
+        )
+        next(processor)
+
+    # Verify data in target database, more specifically that both events have been processed well.
+    assert cratedb.database.refresh_table(table_name) is True
+    assert cratedb.database.count_records(table_name) == 1
+    results = cratedb.database.run_sql(f"SELECT * FROM {table_name}", records=True)  # noqa: S608
+    record = results[0]["data"]
+
+    # Container content amendment.
+    assert record["data"] == {"temperature": 42.5}
+
+    # New attribute added.
+    assert record["new"] == "foo"
+
+    # Attribute deleted.
+    assert "tombstone" not in record
+
+    # Zyp transformation from dt.datetime.
+    assert record["some_date"] == 1720739862000

--- a/tests/util/processor.py
+++ b/tests/util/processor.py
@@ -1,0 +1,38 @@
+import threading
+import time
+
+from cratedb_toolkit.testing.testcontainers.cratedb import CrateDBTestAdapter
+
+
+class BackgroundProcessor:
+    """
+    Manage event processor / stream consumer in separate thread, consuming forever.
+    """
+
+    delay_start = 0.25
+    delay_step = 0.25
+
+    def __init__(self, loader, cratedb: CrateDBTestAdapter):
+        self.loader = loader
+        self.cratedb = cratedb
+        self.table_name = self.loader.cratedb_table
+        self.thread = threading.Thread(target=self.loader.start)
+
+    def __enter__(self):
+        """
+        Start stream consumer.
+        """
+        self.thread.start()
+        time.sleep(self.delay_start)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Stop stream consumer.
+        """
+        self.loader.stop()
+        self.thread.join()
+
+    def __next__(self):
+        time.sleep(self.delay_step)
+        self.cratedb.database.refresh_table(self.table_name)


### PR DESCRIPTION
## About
Make the CDC subsystem more symmetric to the full-load procedure.

## Install
```
pip install 'cratedb-toolkit[mongodb,zyp] @ git+https://github.com/crate/cratedb-toolkit.git@mongodb-cdc-transformations'
```

## Documentation
Minimal variant. Preview.
- https://cratedb-toolkit--288.org.readthedocs.build/io/mongodb/cdc.html#transformations

## Backlog
- [x] Minimal documentation: At least tell the user it is there.
- [x] Software tests: Well, at least add a little test case that exercises CDC together with Zyp.