### PR TITLE
Fix `cratedb-wtf record` about too large values of `ulimit_hard`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Dependencies: Minimize dependencies of core installation,
   defer `polars` to `cratedb-toolkit[io]`.
+- Fixed `cratedb-wtf record` about too large values of `ulimit_hard`
 
 ## 2024/10/13 v0.0.29
 - MongoDB: Added Zyp transformations to the CDC subsystem,

--- a/cratedb_toolkit/wtf/core.py
+++ b/cratedb_toolkit/wtf/core.py
@@ -51,6 +51,9 @@ class InfoContainer(InfoContainerBase):
         data["eco"] = boltons.ecoutils.get_profile(scrub=self.scrub)
         # `version_info` is a list of mixed data types: [3, 11, 6, "final", 0].
         data["eco"]["python"]["version_info"] = str(data["eco"]["python"]["version_info"])
+        # SQLParseException[Value 9223372036854775807 exceeds allowed range for column of type bigint]
+        # "ulimit_hard": 9223372036854775807
+        data["eco"]["ulimit_hard"] = str(data["eco"]["ulimit_hard"])
         # data["libraries"] = PlatformInfo.libraries()  # noqa: ERA001
         return data
 

--- a/doc/wtf/index.md
+++ b/doc/wtf/index.md
@@ -42,6 +42,9 @@ Record complete outcomes of `info` and `job-info`.
 ```shell
 cratedb-wtf record
 ```
+:::{tip}
+See also [](#cfr).
+:::
 
 
 ## HTTP API


### PR DESCRIPTION
Store `ulimit_hard` as STRING instead of BIGINT.

```
{
"ulimit_soft": 256,
"ulimit_hard": "9223372036854775807"
}
```

/cc @WalBeh 
