### PR TITLE
cratedb-datasets: Updated URL to new location for Python Datasets API

### DIFF
--- a/cratedb_toolkit/datasets/tutorial.py
+++ b/cratedb_toolkit/datasets/tutorial.py
@@ -3,36 +3,36 @@ from cratedb_toolkit.datasets.store import registry
 
 devices_info = Dataset(
     reference="tutorial/devices-info",
-    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/devices_info.json.gz",
-    init_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_devices_info.sql",
+    data_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/devices_info.json.gz",
+    init_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/load_devices_info.sql",
     init_includes_loading=True,
 )
 
 devices_readings = Dataset(
     reference="tutorial/devices-readings",
-    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/devices_readings.json.gz",
-    init_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_devices_readings.sql",
+    data_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/devices_readings.json.gz",
+    init_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/load_devices_readings.sql",
     init_includes_loading=True,
 )
 
 marketing = Dataset(
     reference="tutorial/marketing",
-    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_marketing.json.gz",
-    init_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_marketing.sql",
+    data_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/data_marketing.json.gz",
+    init_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/load_marketing.sql",
     init_includes_loading=True,
 )
 
 netflix = Dataset(
     reference="tutorial/netflix",
-    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_netflix.json.gz",
-    init_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_netflix.sql",
+    data_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/data_netflix.json.gz",
+    init_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/load_netflix.sql",
     init_includes_loading=True,
 )
 
 weather = Dataset(
     reference="tutorial/weather-basic",
-    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_weather.csv.gz",
-    init_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_weather.sql",
+    data_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/data_weather.csv.gz",
+    init_url="https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/load_weather.sql",
     init_includes_loading=True,
 )
 

--- a/doc/bugs.md
+++ b/doc/bugs.md
@@ -36,7 +36,7 @@ KeyError: 'url'
 
 
 ```
-$ ctk load table https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_weather.csv.gz --schema foo
+$ ctk load table https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/data_weather.csv.gz --schema foo
 ==> Info: Status: REGISTERED (Your import job was received and is pending processing.)
 ==> Info: Status: SENT (Your creation request was sent to the region.)
 ==> Info: Done importing 70.00K records


### PR DESCRIPTION
## About
Along the lines of GH-339, GH-340, GH-341, to update the dataset URLs to the new location at https://cdn.crate.io/downloads/datasets/cratedb-datasets/.
