### PR TITLE
Query Collector: Respect `CRATEDB_SQLALCHEMY_URL` environment variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Added basic utility command `ctk tail`, for tailing a database
   table, and optionally following the tail
 - Table Loader: Added capability to load InfluxDB Line Protocol (ILP) files
+- Query Collector: Now respects `CRATEDB_SQLALCHEMY_URL` environment variable
 
 ## 2024/10/13 v0.0.29
 - MongoDB: Added Zyp transformations to the CDC subsystem,

--- a/cratedb_toolkit/wtf/query_collector.py
+++ b/cratedb_toolkit/wtf/query_collector.py
@@ -11,11 +11,15 @@ from uuid import uuid4
 import urllib3
 from crate import client
 
+from cratedb_toolkit.model import DatabaseAddress
+
 logger = logging.getLogger(__name__)
 
-host = os.getenv("HOSTNAME", "localhost:4200")
-username = os.getenv("USERNAME", "crate")
-password = os.getenv("PASSWORD", "")
+cratedb_sqlalchemy_url = os.getenv("CRATEDB_SQLALCHEMY_URL", "crate://crate@localhost:4200")
+uri = DatabaseAddress.from_string(cratedb_sqlalchemy_url)
+host = f"{uri.uri.host}:{uri.uri.port}"
+username = uri.uri.username
+password = uri.uri.password
 interval = float(os.getenv("INTERVAL", 10))
 stmt_log_table = os.getenv("STMT_TABLE", "stats.statement_log")
 last_exec_table = os.getenv("LAST_EXEC_TABLE", "stats.last_execution")

--- a/cratedb_toolkit/wtf/query_collector.py
+++ b/cratedb_toolkit/wtf/query_collector.py
@@ -16,13 +16,16 @@ from cratedb_toolkit.model import DatabaseAddress
 logger = logging.getLogger(__name__)
 
 cratedb_sqlalchemy_url = os.getenv("CRATEDB_SQLALCHEMY_URL", "crate://crate@localhost:4200")
-uri = DatabaseAddress.from_string(cratedb_sqlalchemy_url)
-host = f"{uri.uri.host}:{uri.uri.port}"
-username = uri.uri.username
-password = uri.uri.password
+address = DatabaseAddress.from_string(cratedb_sqlalchemy_url)
+host = f"{address.uri.host}:{address.uri.port}"
+username = address.uri.username
+password = address.uri.password
+_, table_address = address.decode()
+schema = table_address.schema or "stats"
+
 interval = float(os.getenv("INTERVAL", 10))
-stmt_log_table = os.getenv("STMT_TABLE", "stats.statement_log")
-last_exec_table = os.getenv("LAST_EXEC_TABLE", "stats.last_execution")
+stmt_log_table = os.getenv("STMT_TABLE", f"{schema}.statement_log")
+last_exec_table = os.getenv("LAST_EXEC_TABLE", f"{schema}.last_execution")
 last_execution_ts = 0
 sys_jobs_log = {}
 bucket_list = [10, 50, 100, 500, 1000, 2000, 5000, 10000, 15000, 20000]

--- a/tests/wtf/test_cli.py
+++ b/tests/wtf/test_cli.py
@@ -2,7 +2,6 @@ import json
 
 from boltons.iterutils import get_path
 from click.testing import CliRunner
-from yarl import URL
 
 from cratedb_toolkit.wtf.cli import cli
 
@@ -94,14 +93,11 @@ def test_wtf_cli_statistics_collect(cratedb, caplog):
     Verify `cratedb-wtf job-statistics collect`.
     """
 
-    uri = URL(cratedb.database.dburi)
-
     # Invoke command.
     runner = CliRunner(env={"CRATEDB_SQLALCHEMY_URL": cratedb.database.dburi})
     result = runner.invoke(
         cli,
         args="job-statistics collect --once",
-        env={"HOSTNAME": f"{uri.host}:{uri.port}"},
         catch_exceptions=False,
     )
     assert result.exit_code == 0


### PR DESCRIPTION
## Problem
`ctk wtf job-statistics collect` did not respect the `CRATEDB_SQLALCHEMY_URL` environment variable yet. Now, it does, and by that, it will also make the table schema configurable.

