### PR TITLE
Dependencies: Update to `crate>=2.0.0.dev6`, restoring JSON marshalling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dependencies = [
   "python-dotenv<2",
   "python-slugify<9",
   "pyyaml<7",
-  "sqlalchemy-cratedb>=0.41.0.dev1",
+  "sqlalchemy-cratedb>=0.41.0.dev2",
   "sqlparse<0.6",
   "tqdm<5",
   'typing-extensions<5; python_version <= "3.7"',

--- a/tests/sqlalchemy/test_patch.py
+++ b/tests/sqlalchemy/test_patch.py
@@ -53,7 +53,7 @@ def test_json_encoder_date():
     """
     data = {"date": datetime.date(2024, 6, 4)}
     encoded = json_dumps(data)
-    assert encoded == b'{"date":"2024-06-04"}'
+    assert encoded == b'{"date":1717459200000}'
 
 
 def test_json_encoder_numpy():


### PR DESCRIPTION
## About
The fundamental patch GH-349 needs a little update, pulling in a more recent pre-release version of crate-python.

## References
- https://github.com/crate/crate-python/pull/691