### PR TITLE
Dependencies: Update to sqlalchemy-cratedb>=0.41.0 (GA)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dependencies = [
   "python-dotenv<2",
   "python-slugify<9",
   "pyyaml<7",
-  "sqlalchemy-cratedb>=0.41.0.dev2",
+  "sqlalchemy-cratedb>=0.41.0",
   "sqlparse<0.6",
   "tqdm<5",
   "typing-extensions<5; python_version<='3.7'",


### PR DESCRIPTION
## About

Update to most recent crate 2.0.0 and sqlalchemy-cratedb 0.41.0.

- https://github.com/crate/crate-python/issues/693
