### PR TITLE
TEMP: Update to "sqlalchemy-cratedb>=0.42.0.dev2"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dependencies = [
   "python-dotenv<2",
   "python-slugify<9",
   "pyyaml<7",
-  "sqlalchemy-cratedb>=0.41.0",
+  "sqlalchemy-cratedb>=0.42.0.dev2",
   "sqlparse<0.6",
   "tqdm<5",
   "typing-extensions<5; python_version<='3.7'",


### PR DESCRIPTION
## About
Just a maintenance update.

## Remarks
Test failures on CI are unrelated to this patch, see https://github.com/crate/crate/issues/17691 instead.

## References
- https://github.com/crate/sqlalchemy-cratedb/pull/215
- https://github.com/crate/cloud-api/pull/3089
- https://github.com/crate/grand-central/pull/208