### PR TITLE
MCP: Update to `mcp-alchemy` GA from PyPI

### DIFF
--- a/cratedb_toolkit/query/mcp/registry.py
+++ b/cratedb_toolkit/query/mcp/registry.py
@@ -44,7 +44,7 @@ It is written in TypeScript, to be invoked with `npx`.
         command="mcp-alchemy",
         env={"DB_URL": "crate://crate@localhost:4200/?schema=testdrive"},
         requirements=[
-            "mcp-alchemy @ git+https://github.com/runekaagaard/mcp-alchemy.git@b85aae6",
+            "mcp-alchemy>=2025.4.8",
             "sqlalchemy-cratedb>=0.42.0.dev1",
         ],
         homepage="https://github.com/runekaagaard/mcp-alchemy",

--- a/doc/query/mcp/landscape.md
+++ b/doc/query/mcp/landscape.md
@@ -170,7 +170,7 @@ The MCP Alchemy MCP server package uses SQLAlchemy to talk to databases and prov
 It is written in Python, optionally to be invoked with `uv` or `uvx`.
 
 :Homepage: https://github.com/runekaagaard/mcp-alchemy
-:Install: `uv pip install 'mcp-alchemy @ git+https://github.com/runekaagaard/mcp-alchemy.git@b85aae6' 'sqlalchemy-cratedb>=0.42.0.dev1'`
+:Install: `uv pip install 'mcp-alchemy>=2025.4.8' 'sqlalchemy-cratedb>=0.42.0.dev1'`
 :Run: `mcp-alchemy`
 
 


### PR DESCRIPTION
## About
MCP Alchemy is now available on PyPI.
https://pypi.org/project/mcp-alchemy/

## References
- https://github.com/crate/cratedb-examples/pull/890