### PR TITLE
Project: Improve configuration for `versioningit`, allow Zip-only setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,8 +343,9 @@ install_types = true
 non_interactive = true
 
 [tool.versioningit.vcs]
-method = "git"
+method = "git-archive"
 default-tag = "0.0.0"
+describe-subst = "$Format:%(describe:match=v*)$"
 
 # ===================
 # Tasks configuration


### PR DESCRIPTION
## Problem
When installing from GitHub using `git+http://...`, the caller needs to have the `git` program installed.

## Solution
By using the `git-archive` method of `versioningit`, it can provide the software version also without.
