### PR TITLE
Docs API: Use stdout by default. Add YAML output format.

### DIFF
--- a/cratedb_toolkit/docs/cli.py
+++ b/cratedb_toolkit/docs/cli.py
@@ -46,9 +46,9 @@ def help_settings():
     "--format",
     "-f",
     "format_",
-    type=click.Choice(["json", "markdown", "sql"]),
+    type=click.Choice(["json", "yaml", "markdown", "sql"]),
     default="json",
-    help="Output format (json, markdown or sql)",
+    help="Output format (json, yaml, markdown or sql)",
 )
 @click.option("--output", "-o", default=None, help="Output file name")
 def settings(format_: str, output: str):
@@ -57,6 +57,7 @@ def settings(format_: str, output: str):
 
     Output in JSON, Markdown, or SQL format.
     """
-    from .settings import extract
+    from .settings import SettingsExtractor
 
-    extract(format_, output)
+    extractor = SettingsExtractor()
+    extractor.acquire().render(format_).write(output)

--- a/cratedb_toolkit/docs/settings.py
+++ b/cratedb_toolkit/docs/settings.py
@@ -3,9 +3,9 @@
 CrateDB Settings Extractor
 
 This tool extracts settings from CrateDB's documentation and outputs them
-in either JSON or Markdown format, or the SQL statements to set the default value.
+in either JSON, YAML, or Markdown format, or the SQL statements to set the default value.
 It parses the HTML structure of the documentation to identify settings, their
-descriptions, default values, and whether they're runtime configurable.
+descriptions, default values, and whether they are runtime configurable or not.
 
 Author: wolta
 Date: April 2025
@@ -623,7 +623,7 @@ class OutputFormat(str, Enum):
 class SettingsExtractor:
     """
     Extract CrateDB settings from documentation.
-    Output in JSON, Markdown, or SQL format.
+    Output in JSON, YAML, Markdown, or SQL format.
     """
 
     settings: Dict[str, Dict[str, Any]] = dataclasses.field(default_factory=dict)

--- a/doc/docs-api.md
+++ b/doc/docs-api.md
@@ -2,7 +2,21 @@
 
 CrateDB Toolkit's Docs API provides programmatic access to CrateDB's documentation.
 
-## CrateDB settings
+## Install
+```shell
+uv pip install 'cratedb-toolkit[docs-api]'
+```
+
+## Usage
+
+### CrateDB settings
+
+This tool extracts settings from CrateDB's documentation and outputs them
+in either JSON, YAML or Markdown formats, or SQL statements to set the default value.
+
+It parses the HTML structure of the documentation to identify settings, their
+descriptions, default values, and whether they are runtime configurable or not.
+
 ```shell
 ctk docs settings --help
 ```

--- a/tests/docs/test_cli.py
+++ b/tests/docs/test_cli.py
@@ -1,35 +1,93 @@
 import json
 from pathlib import Path
 
+import yaml
 from click.testing import CliRunner
 
 from cratedb_toolkit.docs.cli import cli
 
 
-def test_settings():
+def test_settings_json(tmp_path: Path):
     """
     Verify `ctk docs settings`.
     """
-    # Path to the output file.
-    output = Path("cratedb_settings.json")
 
-    # Clean up any existing file before the test.
-    output.unlink(missing_ok=True)
+    output_path = tmp_path / "cratedb-settings.json"
 
     # Invoke command.
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        args="settings",
+        args=f"settings --format=json --output={output_path}",
         catch_exceptions=False,
     )
     assert result.exit_code == 0
 
     # Verify the outcome.
-    assert output.exists(), f"File missing: {output}"
-    data = json.loads(output.read_text())
+    data = json.loads(output_path.read_text())
     assert "whether or not to collect statistical information" in data["stats.enabled"]["purpose"]
 
-    # Clean up after the test
-    if output.exists():
-        output.unlink()
+
+def test_settings_markdown(tmp_path: Path):
+    """
+    Verify `ctk docs settings`.
+    """
+
+    output_path = tmp_path / "cratedb-settings.md"
+
+    # Invoke command.
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        args=f"settings --format=markdown --output={output_path}",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Verify the outcome.
+    data = output_path.read_text()
+    assert "| bulk.request_timeout | 1m | Default: 1m" in data
+    assert "| udc.url | https://udc.crate.io" in data
+
+
+def test_settings_sql(tmp_path: Path):
+    """
+    Verify `ctk docs settings`.
+    """
+
+    output_path = tmp_path / "cratedb-settings.sql"
+
+    # Invoke command.
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        args=f"settings --format=sql --output={output_path}",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Verify the outcome.
+    data = output_path.read_text()
+    assert """SET GLOBAL PERSISTENT "bulk.request_timeout" = '1m';""" in data
+    assert "-- Total statements:" in data
+
+
+def test_settings_yaml(tmp_path: Path):
+    """
+    Verify `ctk docs settings`.
+    """
+
+    output_path = tmp_path / "cratedb-settings.yaml"
+
+    # Invoke command.
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        args=f"settings --format=yaml --output={output_path}",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Verify the outcome.
+    data = yaml.safe_load(output_path.read_text())
+    assert "whether or not to collect statistical information" in data["stats.enabled"]["purpose"]


### PR DESCRIPTION
## About

Streamline and trim the rendering and output writing subsystem a bit.
When no output parameter is given, emit results to stdout.
Also enable rendering into YAML format.

## Python API

```python
from cratedb_toolkit.docs.settings import SettingsExtractor

extractor = SettingsExtractor()
extractor.acquire().render(format).write(output)
```
