### PR TITLE
Connect: Respect `sslmode` URI parameter

### DIFF
--- a/.github/workflows/release-oci.yml
+++ b/.github/workflows/release-oci.yml
@@ -8,7 +8,7 @@ on:
       - '*.*.*'
 
   schedule:
-    - cron: '45 00 * * *'  # every day at 00:45 am
+    - cron: '45 04 * * *'  # every day at 04:45 am
 
   # Allow job to be triggered manually.
   workflow_dispatch:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - MCP: Add subsystem providing a few server and client utilities through
   the `ctk query mcp {list,inquire,launch}` subcommands.
 - Docs API: Added extractors for CrateDB functions and settings
+- Connect: Respect `sslmode` URI parameter when converting SQLAlchemy
+  connection URLs to `http(s)://`
 
 ## 2025/01/31 v0.0.31
 - Fixed connectivity for `jobstats collect`

--- a/cratedb_toolkit/cfr/jobstats.py
+++ b/cratedb_toolkit/cfr/jobstats.py
@@ -54,7 +54,13 @@ def boot(address: DatabaseAddress):
 
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     logger.info(f"Connecting to {address.httpuri}")
-    conn = client.connect(address.httpuri, username=address.username, password=address.password, schema=schema)
+    conn = client.connect(
+        address.httpuri,
+        username=address.username,
+        password=address.password,
+        schema=schema,
+        verify_ssl_cert=address.verify_ssl,
+    )
     cursor = conn.cursor()
     last_scrape = int(time.time() * 1000) - int(interval * 60000)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,14 +1,24 @@
 from cratedb_toolkit.model import DatabaseAddress
 
 
-def test_database_address_to_httpuri_standard():
+def test_database_address_to_httpuri_standard_default_port():
     address = DatabaseAddress.from_string("crate://user:password@example.org/schema/table")
-    assert address.httpuri == "http://user:password@example.org/schema/table"
+    assert address.httpuri == "http://user:password@example.org:4200/schema/table"
 
 
-def test_database_address_to_httpuri_ssl():
+def test_database_address_to_httpuri_standard_with_port():
+    address = DatabaseAddress.from_string("crate://user:password@example.org:3333/schema/table")
+    assert address.httpuri == "http://user:password@example.org:3333/schema/table"
+
+
+def test_database_address_to_httpuri_ssl_default_port():
     address = DatabaseAddress.from_string("crate://user:password@example.org/schema/table?ssl=true")
-    assert address.httpuri == "https://user:password@example.org/schema/table"
+    assert address.httpuri == "https://user:password@example.org:4200/schema/table"
+
+
+def test_database_address_to_httpuri_ssl_with_port():
+    address = DatabaseAddress.from_string("crate://user:password@example.org:3333/schema/table?ssl=true")
+    assert address.httpuri == "https://user:password@example.org:3333/schema/table"
 
 
 def test_database_address_from_httpuri_standard():
@@ -19,3 +29,15 @@ def test_database_address_from_httpuri_standard():
 def test_database_address_from_httpuri_ssl():
     address = DatabaseAddress.from_httpuri("https://user:password@example.org/schema/table")
     assert address.dburi == "crate://user:password@example.org/schema/table?ssl=true"
+
+
+def test_database_address_to_httpuri_sslmode_require():
+    address = DatabaseAddress.from_string("crate://user:password@example.org/schema/table?sslmode=require")
+    assert address.httpuri == "https://user:password@example.org:4200/schema/table"
+    assert address.verify_ssl is False
+
+
+def test_database_address_to_httpuri_sslmode_verify_ca():
+    address = DatabaseAddress.from_string("crate://user:password@example.org/schema/table?sslmode=verify-ca")
+    assert address.httpuri == "https://user:password@example.org:4200/schema/table"
+    assert address.verify_ssl is True


### PR DESCRIPTION
## Problem
The new `?sslmode=require` parameter with the `CRATEDB_SQLALCHEMY_URL` environment variable wasn't respected by the [CFR job statistics](https://cratedb-toolkit.readthedocs.io/cfr/jobstats.html) subsystem.
```shell
export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost/?sslmode=require
ctk cfr jobstats collect
```

## Solution
Respect `sslmode` URI parameter when converting SQLAlchemy connection URLs to `http(s)://`.
