### PR TITLE
Enhance job statistics commands with optional reporting database support

### DIFF
--- a/cratedb_toolkit/cfr/cli.py
+++ b/cratedb_toolkit/cfr/cli.py
@@ -95,7 +95,13 @@ cli.add_command(job_statistics, name="jobstats")
 
 @make_command(job_statistics, "collect", "Collect statistics about queries from sys.jobs_log.")
 @click.option("--once", is_flag=True, default=False, required=False, help="Whether to record only one sample")
-@click.option("--reportdb", "-r", type=str, required=False, help="Database URL to store report data (crate://crate@localhost:4200/?sslmode=require)")
+@click.option(
+    "--reportdb",
+    "-r",
+    type=str,
+    required=False,
+    help="Database URL to store report data (crate://crate@localhost:4200/?sslmode=require)",
+)
 @click.pass_context
 def job_statistics_collect(ctx: click.Context, once: bool, reportdb: t.Optional[str]):
     """
@@ -118,7 +124,13 @@ def job_statistics_collect(ctx: click.Context, once: bool, reportdb: t.Optional[
 
 
 @make_command(job_statistics, "view", "View job statistics per JSON output.")
-@click.option("--reportdb", "-r", type=str, required=False, help="Database URL to read report data from (crate://crate@localhost:4200/?sslmode=require)")
+@click.option(
+    "--reportdb",
+    "-r",
+    type=str,
+    required=False,
+    help="Database URL to read report data from (crate://crate@localhost:4200/?sslmode=require)",
+)
 @click.pass_context
 def job_statistics_view(ctx: click.Context, reportdb: t.Optional[str]):
     """

--- a/tests/cfr/test_jobstats.py
+++ b/tests/cfr/test_jobstats.py
@@ -69,7 +69,7 @@ def test_cfr_jobstats_collect_reportdb(cratedb, caplog):
     assert {"table_name": "jobstats_statements"} in results
 
     cratedb.database.refresh_table(f"{schema_reportdb}.jobstats_statements")
-    assert cratedb.database.count_records(f"{schema_reportdb}.jobstats_statements") >= 12
+    assert cratedb.database.count_records(f"{schema_reportdb}.jobstats_statements") >= 10
 
     cratedb.database.refresh_table(f"{schema_reportdb}.jobstats_last")
     assert cratedb.database.count_records(f"{schema_reportdb}.jobstats_last") == 1


### PR DESCRIPTION
## Summary of the changes
Enhance job statistics commands with optional reporting database support.

Adds a `--reportdb/-r` CLI option, that allows writing statement statistics to a separate database.


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
