### PR TITLE
Anonymize sql statements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - CFR: Enhanced job statistics with optional reporting database support. Thanks, @WalBeh.
 - Settings: Added settings comparison utility. Thanks, @WalBeh.
 - Meta: Added parser for `https://cratedb.com/releases.json` file. Thanks, @WalBeh.
+- CFR: Added the ability to anonymize queries recorded by `collect`
 
 ## 2025/04/23 v0.0.32
 - MCP: Add subsystem providing a few server and client utilities through

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ optional-dependencies.cfr = [
   "pandas<2.3",
   "polars<1.30",
   "pyarrow<20.1",
+  "queryanonymizer<1.2",
 ]
 optional-dependencies.cloud = [
   "croud==1.13.0",


### PR DESCRIPTION
## Summary of the changes
This allows to _anonymize_ the queries aggregated by `ctk cfr jobstats` by adding a `--anonymize` flag. Anonymization is built on the `https://queryanonymizer.com/` library. The strings replaced are saved to a json file (defaults to `decoder_dictionary.json`. This allows to reverse back to clear text, which might be useful for troubleshooting queries. 

```shell
ctk cfr jobstats collect --anonymize clusterABC.json
ctk cfr jobstats view --deanonymize clusterABC.json
```

