### PR TITLE
Meta: Add parser for `https://cratedb.com/releases.json` file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - CFR: Enhanced job statistics with optional reporting database support. Thanks, @WalBeh.
 - Settings: Added settings comparison utility. Thanks, @WalBeh.
+- Meta: Added parser for `https://cratedb.com/releases.json` file. Thanks, @WalBeh.
 
 ## 2025/04/23 v0.0.32
 - MCP: Add subsystem providing a few server and client utilities through

--- a/cratedb_toolkit/meta/release.py
+++ b/cratedb_toolkit/meta/release.py
@@ -1,0 +1,65 @@
+import dataclasses
+from pathlib import Path
+
+import requests
+
+
+@dataclasses.dataclass
+class ReleaseItem:
+    """
+    Manage information about a single release item.
+    """
+
+    category: str
+    version: str
+    date: str
+    type: str
+    url: str
+
+    @property
+    def cloud_version(self) -> str:
+        """
+        Get a release tag for the latest nightly release, suitable for use in CrateDB Cloud with the "nightly" channel.
+
+        Example: nightly-6.0.0-2025-05-01-00-02
+        """
+        tag = Path(self.url).with_suffix("").stem
+        if self.category == "nightly":
+            tag = tag[:-8]
+        return tag.replace("crate-", f"{self.category}-")
+
+
+class CrateDBRelease:
+    """
+    Relay information about CrateDB releases.
+    """
+
+    URL = "https://cratedb.com/releases.json"
+
+    def __init__(self):
+        self.data = requests.get(self.URL, timeout=5).json()
+
+    @property
+    def stable(self):
+        return self._release_item("stable")
+
+    @property
+    def testing(self):
+        return self._release_item("testing")
+
+    @property
+    def nightly(self):
+        return self._release_item("nightly")
+
+    def _release_item(self, category: str):
+        """
+        Create a ReleaseItem instance for the given category.
+        """
+        slot = self.data[category]
+        return ReleaseItem(
+            category=category,
+            version=slot["version"],
+            date=slot["date"],
+            type="tarball",
+            url=slot["downloads"]["tar.gz"]["url"],
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ dependencies = [
   "python-dotenv<2",
   "python-slugify<9",
   "pyyaml<7",
+  "requests>=2.28,<3",
   "sqlalchemy-cratedb>=0.42.0.dev2",
   "sqlparse<0.6",
   "tqdm<5",

--- a/tests/meta/test_release.py
+++ b/tests/meta/test_release.py
@@ -1,0 +1,34 @@
+from cratedb_toolkit.meta.release import CrateDBRelease
+
+
+def test_release_stable():
+    cr = CrateDBRelease()
+    assert cr.stable.category == "stable"
+    assert cr.stable.version >= "5.10.5"
+    assert cr.stable.date >= "2025-04-30"
+    assert cr.stable.type == "tarball"
+    assert cr.stable.url >= "https://cdn.crate.io/downloads/releases/crate-5.10.5.tar.gz"
+    assert cr.stable.cloud_version.startswith("stable-")
+    assert cr.stable.cloud_version >= "stable-5.10.5"
+
+
+def test_release_testing():
+    cr = CrateDBRelease()
+    assert cr.testing.category == "testing"
+    assert cr.testing.version >= "5.10.5"
+    assert cr.testing.date >= "2025-04-28"
+    assert cr.testing.type == "tarball"
+    assert cr.testing.url >= "https://cdn.crate.io/downloads/releases/crate-5.10.5.tar.gz"
+    assert cr.testing.cloud_version.startswith("testing-")
+    assert cr.testing.cloud_version >= "testing-5.10.5"
+
+
+def test_release_nightly():
+    cr = CrateDBRelease()
+    assert cr.nightly.category == "nightly"
+    assert cr.nightly.version >= "6.0.0"
+    assert cr.nightly.date >= "2025-05-01"
+    assert cr.nightly.type == "tarball"
+    assert cr.nightly.url >= "https://cdn.crate.io/downloads/releases/crate-5.10.5.tar.gz"
+    assert cr.nightly.cloud_version.startswith("nightly-")
+    assert cr.nightly.cloud_version >= "nightly-6.0.0-2025-05-01-00-02"


### PR DESCRIPTION
## About
On day-to-day workflows, it is common to extract information from https://cratedb.com/releases.json, in order to pin-point specific release artefacts. The routines added here will make those operations more fluent, with less bashisms.

## Details
The blueprint was this routine in `scripts/croud-deploy-nightly.sh`. Thanks, @WalBeh.
```shell
nightly_url="$(curl -s https://cratedb.com/releases.json | jq -r '.nightly.downloads."tar.gz".url')"
# strip everything before the version
nightly="$(echo $nightly_url | sed 's/^.*crate-//')"
# prepend "nightly-" and strip ".tar.gz"
nightly="nightly-${nightly%%.tar.gz}"
# remove short hash
nightly="${nightly:0:-8}"
```

## References
- CrateDB "nightly" support for GH-81