### PR TITLE
Downgrade to sqlalchemy-cratedb 0.41, version 0.42 is not GA yet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Downgraded to sqlalchemy-cratedb 0.41, version 0.42 is not GA yet
 
 ## 2025/05/12 v0.0.33
 - CFR: Enhanced job statistics with optional reporting database support. Thanks, @WalBeh.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ dependencies = [
   "python-slugify<9",
   "pyyaml<7",
   "requests>=2.28,<3",
-  "sqlalchemy-cratedb>=0.42.0.dev2",
+  "sqlalchemy-cratedb>=0.41",
   "sqlparse<0.6",
   "tqdm<5",
   "typing-extensions<5; python_version<='3.7'",


### PR DESCRIPTION
What the title says.