### PR TITLE
Added lost `pytest` dependencies to `cratedb-toolkit[testing]`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Added lost `pytest` dependencies to `cratedb-toolkit[testing]`
 
 ## 2025/05/13 v0.0.34
 - Downgraded to sqlalchemy-cratedb 0.41, version 0.42 is not GA yet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,9 @@ optional-dependencies.test-mongodb = [
   "testcontainers-mongodb==0.0.1rc1",
 ]
 optional-dependencies.testing = [
+  "pytest<9",
+  "pytest-cov<7",
+  "pytest-mock<4",
   "testcontainers<5",
 ]
 urls.Changelog = "https://github.com/crate/cratedb-toolkit/blob/main/CHANGES.md"


### PR DESCRIPTION
71d29e7851bfdb apparently removed essential dependencies accidentally.