### PR TITLE
Dependencies: Migrate from `zyp` to `tikray`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Dependencies: Migrated from `zyp` to `tikray`. It's effectively the
+  same, but provided using a dedicated package now
 
 ## 2025/05/13 v0.0.35
 - Added lost `pytest` dependencies to `cratedb-toolkit[testing]`

--- a/cratedb_toolkit/io/cli.py
+++ b/cratedb_toolkit/io/cli.py
@@ -34,7 +34,7 @@ def cli(ctx: click.Context, verbose: bool, debug: bool):
 @click.option("--table", envvar="CRATEDB_TABLE", type=str, required=False, help="Table where to import the data")
 @click.option("--format", "format_", type=str, required=False, help="File format of the import resource")
 @click.option("--compression", type=str, required=False, help="Compression format of the import resource")
-@click.option("--transformation", type=Path, required=False, help="Path to Zyp transformation file")
+@click.option("--transformation", type=Path, required=False, help="Path to Tikray transformation file")
 @click.pass_context
 def load_table(
     ctx: click.Context,

--- a/cratedb_toolkit/io/mongodb/api.py
+++ b/cratedb_toolkit/io/mongodb/api.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from boltons.urlutils import URL
 from polars.exceptions import PanicException
-from zyp.model.project import TransformationProject
+from tikray.model.project import ProjectTransformation
 
 from cratedb_toolkit.io.mongodb.adapter import mongodb_adapter_factory
 from cratedb_toolkit.io.mongodb.cdc import MongoDBCDCRelayCrateDB
@@ -19,7 +19,13 @@ from cratedb_toolkit.util.database import DatabaseAdapter
 logger = logging.getLogger(__name__)
 
 
-def mongodb_copy_migr8(source_url, target_url, transformation: Path = None, limit: int = 0, progress: bool = False):
+def mongodb_copy_migr8(
+    source_url,
+    target_url,
+    transformation: t.Union[Path, TransformationManager, ProjectTransformation, None] = None,
+    limit: int = 0,
+    progress: bool = False,
+):
     """
     Transfer MongoDB collection using migr8.
 
@@ -100,7 +106,7 @@ def mongodb_copy_migr8(source_url, target_url, transformation: Path = None, limi
 def mongodb_copy(
     source_url: t.Union[str, URL],
     target_url: t.Union[str, URL],
-    transformation: t.Union[Path, TransformationManager, TransformationProject, None] = None,
+    transformation: t.Union[Path, TransformationManager, ProjectTransformation, None] = None,
     progress: bool = False,
 ):
     """
@@ -184,7 +190,7 @@ def mongodb_copy(
 def mongodb_relay_cdc(
     source_url,
     target_url,
-    transformation: t.Union[Path, TransformationManager, TransformationProject, None] = None,
+    transformation: t.Union[Path, TransformationManager, ProjectTransformation, None] = None,
 ):
     """
     Synopsis

--- a/cratedb_toolkit/io/mongodb/cdc.py
+++ b/cratedb_toolkit/io/mongodb/cdc.py
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 from boltons.urlutils import URL
 from commons_codec.transform.mongodb import MongoDBCDCTranslator, MongoDBCrateDBConverter
 from pymongo.change_stream import CollectionChangeStream
-from zyp.model.collection import CollectionAddress
+from tikray.model.collection import CollectionAddress
 
 from cratedb_toolkit.io.mongodb.adapter import mongodb_adapter_factory
 from cratedb_toolkit.io.mongodb.model import DocumentDict

--- a/cratedb_toolkit/io/mongodb/cli.py
+++ b/cratedb_toolkit/io/mongodb/cli.py
@@ -25,7 +25,7 @@ def extract_parser(subargs):
         help="Whether to fully scan the MongoDB collections or only partially.",
     )
     parser.add_argument("--limit", type=int, default=0, required=False, help="Limit export to N documents")
-    parser.add_argument("--transformation", type=Path, required=False, help="Zyp transformation file")
+    parser.add_argument("--transformation", type=Path, required=False, help="Tikray transformation file")
     parser.add_argument("-o", "--out", required=False)
 
 
@@ -43,7 +43,7 @@ def export_parser(subargs):
     parser.add_argument("--database", required=True, help="MongoDB database")
     parser.add_argument("--collection", required=True, help="MongoDB collection to export")
     parser.add_argument("--limit", type=int, default=0, required=False, help="Limit export to N documents")
-    parser.add_argument("--transformation", type=Path, required=False, help="Zyp transformation file")
+    parser.add_argument("--transformation", type=Path, required=False, help="Tikray transformation file")
 
 
 def get_args():

--- a/cratedb_toolkit/io/mongodb/copy.py
+++ b/cratedb_toolkit/io/mongodb/copy.py
@@ -5,9 +5,9 @@ import typing as t
 import sqlalchemy as sa
 from boltons.urlutils import URL
 from commons_codec.transform.mongodb import MongoDBCrateDBConverter, MongoDBFullLoadTranslator
+from tikray.model.collection import CollectionAddress
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
-from zyp.model.collection import CollectionAddress
 
 from cratedb_toolkit.io.core import BulkProcessor
 from cratedb_toolkit.io.mongodb.adapter import mongodb_adapter_factory

--- a/cratedb_toolkit/io/mongodb/transform.py
+++ b/cratedb_toolkit/io/mongodb/transform.py
@@ -3,14 +3,14 @@ import typing as t
 from pathlib import Path
 
 from jsonpointer import JsonPointer
-from zyp.model.collection import CollectionAddress, CollectionTransformation
-from zyp.model.project import TransformationProject
+from tikray.model.collection import CollectionAddress, CollectionTransformation
+from tikray.model.project import ProjectTransformation
 
 logger = logging.getLogger(__name__)
 
 
 class TransformationManager:
-    def __init__(self, project: TransformationProject):
+    def __init__(self, project: ProjectTransformation):
         self.project = project
         self.active = True
 
@@ -20,7 +20,7 @@ class TransformationManager:
             return None
         elif isinstance(transformation, TransformationManager):
             return transformation
-        elif isinstance(transformation, TransformationProject):
+        elif isinstance(transformation, ProjectTransformation):
             return cls(project=transformation)
         elif isinstance(transformation, Path):
             return cls.from_path(path=transformation)
@@ -33,8 +33,8 @@ class TransformationManager:
             return None
         if not path.exists():
             raise FileNotFoundError(f"File does not exist: {path}")
-        logger.info("Loading Zyp transformation file: %s", path)
-        project = TransformationProject.from_yaml(path.read_text())
+        logger.info("Loading Tikray transformation file: %s", path)
+        project = ProjectTransformation.from_yaml(path.read_text())
         return cls(project=project)
 
     def apply_type_overrides(self, database_name: str, collection_name: str, collection_schema: t.Dict[str, t.Any]):

--- a/doc/backlog/main.md
+++ b/doc/backlog/main.md
@@ -56,7 +56,7 @@
   > single column in CrateDB.
   >
   > The transformation recipe attempts to outline a few features provided by
-  > Zyp Transformations, in this case exclusively applying transformations
+  > Tikray Transformations, in this case exclusively applying transformations
   > described by expressions written in jqlang.
 - MongoDB/Docs: Describe usage of `mongoimport` and `mongoexport`.
   ```shell

--- a/doc/io/mongodb/cdc.md
+++ b/doc/io/mongodb/cdc.md
@@ -112,7 +112,7 @@ crash --hosts "${CRATEDB_CLUSTER_URL}" --command 'SELECT * FROM "testdrive"."dem
 
 
 ## Transformations
-You can use [Zyp Transformations] to change the shape of the data while being
+You can use [Tikray Transformations] to change the shape of the data while being
 transferred. In order to add it to the pipeline, use the `--transformation`
 command line option.
 
@@ -160,4 +160,4 @@ mongosh "${MONGODB_URL}" --eval 'db.demo.drop()'
 [MongoDB Atlas]: https://www.mongodb.com/atlas
 [MongoDB Change Stream]: https://www.mongodb.com/docs/manual/changeStreams/
 [SDK and CLI for CrateDB Cloud Cluster APIs]: https://github.com/crate-workbench/cratedb-toolkit/pull/81
-[Zyp Transformations]: https://commons-codec.readthedocs.io/zyp/
+[Tikray Transformations]: https://tikray.readthedocs.io/

--- a/doc/io/mongodb/loader.md
+++ b/doc/io/mongodb/loader.md
@@ -127,12 +127,12 @@ Use the HTTP URL query parameter `offset` on the source URL, like
 beginning.
 
 ## Transformations
-You can use [Zyp Transformations] to change the shape of the data while being
-transferred. In order to add it to the pipeline, use the `--transformation`
+You can use [Tikray Transformations] to change the shape of the data while being
+transferred. To add it to the pipeline, use the `--transformation`
 command line option.
 
 It is also available for the `migr8 extract` and `migr8 export` commands.
-Example transformation files in YAML format can be explored at [examples/zyp].
+Example transformation files in YAML format can be explored at [examples/tikray].
 
 
 ## Appendix
@@ -174,11 +174,11 @@ Acquire a copy of the repository.
 ```shell
 git clone https://github.com/ozlerhakan/mongodb-json-files.git
 ```
-The data import uses a Zyp project file [zyp-mongodb-json-files.yaml] that
+The data import uses a Tikray project file [tikray-mongodb-json-files.yaml] that
 describes a few adjustments needed to import all files flawlessly. Let's
 acquire that file.
 ```shell
-wget https://github.com/crate/cratedb-toolkit/raw/v0.0.22/examples/zyp/zyp-mongodb-json-files.yaml
+wget https://github.com/crate/cratedb-toolkit/raw/v0.0.36/examples/tikray/tikray-mongodb-json-files.yaml
 ```
 Load all referenced `.json` files into corresponding tables within the CrateDB
 schema `datasets`, using a batch size of 2,500 items.
@@ -186,7 +186,7 @@ schema `datasets`, using a batch size of 2,500 items.
 ctk load table \
   "file+bson:///path/to/mongodb-json-files/datasets/*.json?batch-size=2500" \
   --CRATEDB_CLUSTER_URL-url="crate://crate@localhost:4200/datasets" \
-  --transformation zyp-mongodb-json-files.yaml
+  --transformation tikray-mongodb-json-files.yaml
 ```
 
 :::{rubric} Query
@@ -240,9 +240,9 @@ recent versions like MongoDB 7 and tools version 100.9.5 or higher.
 
 
 [BSON]: https://en.wikipedia.org/wiki/BSON
-[examples/zyp]: https://github.com/crate/cratedb-toolkit/tree/main/examples/zyp
+[examples/tikray]: https://github.com/crate/cratedb-toolkit/tree/main/examples/tikray
 [libbson test files]: https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson/tests/json
 [MongoDB Extended JSON]: https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/
 [mongodb-json-files]: https://github.com/ozlerhakan/mongodb-json-files
-[Zyp Transformations]: https://commons-codec.readthedocs.io/zyp/
-[zyp-mongodb-json-files.yaml]: https://github.com/crate/cratedb-toolkit/blob/v0.0.22/examples/zyp/zyp-mongodb-json-files.yaml
+[Tikray Transformations]: https://tikray.readthedocs.io/
+[tikray-mongodb-json-files.yaml]: https://github.com/crate/cratedb-toolkit/blob/v0.0.36/examples/tikray/tikray-mongodb-json-files.yaml

--- a/doc/io/mongodb/migr8.md
+++ b/doc/io/mongodb/migr8.md
@@ -222,13 +222,13 @@ Alternatively, use [cr8] to directly write the MongoDB collection into a CrateDB
         cr8 insert-json --hosts localhost:4200 --table test
 
 
-### Using Zyp transformations
-You can use [Zyp transformations] to change the shape of the data while being
-transferred. In order to add it to the pipeline, use the `--transformation`
+### Using Tikray transformations
+You can use [Tikray transformations] to change the shape of the data while being
+transferred. To add it to the pipeline, use the `--transformation`
 command line option on the `migr8 extract` and `migr8 export` commands.
 
-You can find an example file at `examples/zyp-transformation.yaml`.
+You can find an example file at `examples/tikray/tikray-transformation.yaml`.
 
 
 [cr8]: https://github.com/mfussenegger/cr8
-[Zyp transformations]: https://commons-codec.readthedocs.io/zyp/index.html
+[Tikray transformations]: https://tikray.readthedocs.io/

--- a/examples/tikray/tikray-int64-to-timestamp.yaml
+++ b/examples/tikray/tikray-int64-to-timestamp.yaml
@@ -1,11 +1,11 @@
-# Zyp transformation defining a schema override on a top-level column.
+# Tikray transformation defining a schema override on a top-level column.
 
 # Timestamps in Unixtime/Epoch format are sometimes stored as
 # int64 / BIGINT. This transformation defines an adjustment to
 # make the target schema use a native datetime/timestamp column.
 ---
 meta:
-  type: zyp-project
+  type: tikray-project
   version: 1
 collections:
 - address:

--- a/examples/tikray/tikray-mongodb-json-files.yaml
+++ b/examples/tikray/tikray-mongodb-json-files.yaml
@@ -1,14 +1,14 @@
-# A Zyp Transformation [1] file to support importing datasets
+# Tikray transformation [1] file to support importing datasets
 # from mongodb-json-files [2] into CrateDB [3].
 #
 # Because CrateDB
 #
-# [1] https://commons-codec.readthedocs.io/zyp/
+# [1] https://tikray.readthedocs.io/
 # [2] https://github.com/ozlerhakan/mongodb-json-files
 # [3] https://cratedb.com/docs/guide/feature/
 ---
 meta:
-  type: zyp-project
+  type: tikray-project
   version: 1
 collections:
 - address:

--- a/examples/tikray/tikray-transformation.yaml
+++ b/examples/tikray/tikray-transformation.yaml
@@ -1,5 +1,5 @@
 meta:
-  type: zyp-project
+  type: tikray-project
   version: 1
 collections:
 - address:

--- a/examples/tikray/tikray-treatment-all.yaml
+++ b/examples/tikray/tikray-treatment-all.yaml
@@ -1,7 +1,7 @@
-# Zyp transformation defining a few special treatments to be applied to inbound data.
+# Tikray transformation defining a few special treatments to be applied to inbound data.
 ---
 meta:
-  type: zyp-project
+  type: tikray-project
   version: 1
 collections:
 - address:

--- a/examples/tikray/tikray-treatment-ignore.yaml
+++ b/examples/tikray/tikray-treatment-ignore.yaml
@@ -1,7 +1,7 @@
-# Zyp transformation defining a few special treatments to be applied to inbound data.
+# Tikray transformation defining a few special treatments to be applied to inbound data.
 ---
 meta:
-  type: zyp-project
+  type: tikray-project
   version: 1
 collections:
 - address:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,12 +187,13 @@ optional-dependencies.mcp = [
   "mcp<1.5; python_version>='3.10'",
 ]
 optional-dependencies.mongodb = [
-  "commons-codec[mongodb,zyp]>=0.0.22",
+  "commons-codec[mongodb]>=0.0.22",
   "cratedb-toolkit[io]",
   "orjson>=3.3.1,<4",
   "pymongo>=3.10.1,<4.10",
   "python-bsonjs<0.7",
   "rich>=3.3.2,<15",
+  "tikray>=0.2,<0.3",
   "undatum<1.1",
 ]
 optional-dependencies.pymongo = [

--- a/tests/io/mongodb/test_cdc.py
+++ b/tests/io/mongodb/test_cdc.py
@@ -34,7 +34,7 @@ def test_mongodb_cdc_insert_update(caplog, mongodb_replicaset, cratedb):
     cratedb_url = f"{cratedb.get_connection_url()}/testdrive/demo"
 
     # Optionally configure transformations.
-    tm = TransformationManager.from_any(Path("examples/zyp/zyp-transformation.yaml"))
+    tm = TransformationManager.from_any(Path("examples/tikray/tikray-transformation.yaml"))
 
     # Initialize table loader.
     table_loader = MongoDBCDCRelayCrateDB(
@@ -78,5 +78,5 @@ def test_mongodb_cdc_insert_update(caplog, mongodb_replicaset, cratedb):
     # Attribute deleted.
     assert "tombstone" not in record
 
-    # Zyp transformation from dt.datetime.
+    # Tikray transformation from dt.datetime.
     assert record["some_date"] == 1720739862000

--- a/tests/io/mongodb/test_cli.py
+++ b/tests/io/mongodb/test_cli.py
@@ -136,7 +136,7 @@ def test_mongodb_load_table_complex_lists_normalize(caplog, cratedb, mongodb):
     demo = testdrive.create_collection("demo")
     demo.insert_many([DOCUMENT_IN])
 
-    transformation = Path("examples/zyp/zyp-treatment-all.yaml")
+    transformation = Path("examples/tikray/tikray-treatment-all.yaml")
 
     # Run transfer command.
     runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb_url})
@@ -176,7 +176,7 @@ def test_mongodb_load_table_complex_lists_ignore(caplog, cratedb, mongodb):
     demo = testdrive.create_collection("demo")
     demo.insert_many([DOCUMENT_IN])
 
-    transformation = Path("examples/zyp/zyp-treatment-ignore.yaml")
+    transformation = Path("examples/tikray/tikray-treatment-ignore.yaml")
 
     # Run transfer command.
     runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb_url})

--- a/tests/io/mongodb/test_copy.py
+++ b/tests/io/mongodb/test_copy.py
@@ -6,9 +6,9 @@ from unittest import mock
 import bson
 import pymongo
 import pytest
-from zyp import CollectionTransformation, MokshaTransformation
-from zyp.model.collection import CollectionAddress
-from zyp.model.project import TransformationProject
+from tikray import CollectionTransformation, MokshaTransformation
+from tikray.model.collection import CollectionAddress
+from tikray.model.project import ProjectTransformation
 
 from cratedb_toolkit.io.mongodb.api import mongodb_copy
 from tests.conftest import check_sqlalchemy2
@@ -333,7 +333,7 @@ def test_mongodb_copy_http_json_relaxed_books(caplog, cratedb):
     cratedb_url = f"{cratedb.get_connection_url()}/testdrive/demo"
 
     # Run transfer command.
-    transformation = TransformationProject().add(
+    transformation = ProjectTransformation().add(
         CollectionTransformation(
             address=CollectionAddress(container="datasets", name="books"),
             pre=MokshaTransformation().jq(".[] |= (._id |= tostring)"),
@@ -377,7 +377,7 @@ def test_mongodb_copy_http_json_relaxed_products(caplog, cratedb):
       | if (.limits.voice.n) then .limits.voice.n |= tostring end
     )
     """
-    transformation = TransformationProject().add(
+    transformation = ProjectTransformation().add(
         CollectionTransformation(
             address=CollectionAddress(container="datasets", name="products"),
             pre=MokshaTransformation().jq(jqlang_transformation),

--- a/tests/io/mongodb/test_transformation.py
+++ b/tests/io/mongodb/test_transformation.py
@@ -35,7 +35,7 @@ def test_mongodb_copy_transform_timestamp(caplog, cratedb, mongodb):
     mongodb_copy(
         mongodb_url,
         cratedb_url,
-        transformation=Path("examples/zyp/zyp-int64-to-timestamp.yaml"),
+        transformation=Path("examples/tikray/tikray-int64-to-timestamp.yaml"),
     )
 
     # Verify data in target database.
@@ -56,7 +56,7 @@ def test_mongodb_copy_transform_timestamp(caplog, cratedb, mongodb):
 
 def test_mongodb_copy_treatment_all(caplog, cratedb, mongodb):
     """
-    Verify MongoDB -> CrateDB data transfer with Zyp Treatment transformation.
+    Verify MongoDB -> CrateDB data transfer with Tikray Treatment transformation.
     """
 
     data_in = {
@@ -100,7 +100,7 @@ def test_mongodb_copy_treatment_all(caplog, cratedb, mongodb):
     mongodb_copy(
         mongodb_url,
         cratedb_url,
-        transformation=Path("examples/zyp/zyp-treatment-all.yaml"),
+        transformation=Path("examples/tikray/tikray-treatment-all.yaml"),
     )
 
     # Verify data in target database.


### PR DESCRIPTION
## About
It's effectively the same, but provided using a dedicated package now.

PyPI: https://pypi.org/project/tikray/
Documentation: https://tikray.readthedocs.io/

## References
- https://github.com/crate/commons-codec/pull/105
