### PR TITLE
Fix comparison of 0s vs 0ms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Settings: Fixed comparison of `0s` vs `0ms`. Thanks, @hlcianfagna.
 
 ## 2025/06/23 v0.0.36
 - Dependencies: Migrated from `zyp` to `tikray`. It's effectively the

--- a/cratedb_toolkit/settings/compare.py
+++ b/cratedb_toolkit/settings/compare.py
@@ -157,6 +157,9 @@ def compare_time_settings(setting_key, current_value, default_value):
     if current_ms is None or default_ms is None:
         return None
 
+    if current_ms == 0 and default_ms == 0:
+        return None
+
     # Special handling for 0 values - always show if one is zero and the other isn't
     if (current_ms == 0 and default_ms > 0) or (default_ms == 0 and current_ms > 0):
         return f"{setting_key}: {current_value} (default: {default_value})"


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Preview: `pip install --upgrade 'cratedb-toolkit[settings] @ git+https://github.com/crate/cratedb-toolkit.git@hlcianfagna/ctksettingscomparedefault0sdisabled'`

This addresses the issue of `stats.jobs_log_expiration` and `stats.operations_log_expiration` being flagged as not being default because the settings reads `0s` but the documentation says `0s (disabled)`