### PR TITLE
Kinesis: Improve argument parsing for stream ARNs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Settings: Fixed comparison of `0s` vs `0ms`. Thanks, @hlcianfagna.
+- Kinesis: Improved argument parsing for stream ARNs. Thanks, @hammerhead.
 
 ## 2025/06/23 v0.0.36
 - Dependencies: Migrated from `zyp` to `tikray`. It's effectively the


### PR DESCRIPTION
## About
Support Kinesis stream ARNs with async-kinesis 2.x only.

## References
- GH-443
