### PR TITLE
DMS: Accept a recipe file to receive settings and parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Settings: Fixed comparison of `0s` vs `0ms`. Thanks, @hlcianfagna.
 - DMS: Provided a recipe file to relay primary key and column type map information
+- DMS: Provided a recipe option to ignore processing DMS control DDL events
 
 ## 2025/06/23 v0.0.36
 - Dependencies: Migrated from `zyp` to `tikray`. It's effectively the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - Settings: Fixed comparison of `0s` vs `0ms`. Thanks, @hlcianfagna.
 - DMS: Provided a recipe file to relay primary key and column type map information
 - DMS: Provided a recipe option to ignore processing DMS control DDL events
+- DMS: Started using the "direct" column mapping by default,
+  retaining the "universal" column mapping optionally.
 
 ## 2025/06/23 v0.0.36
 - Dependencies: Migrated from `zyp` to `tikray`. It's effectively the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Settings: Fixed comparison of `0s` vs `0ms`. Thanks, @hlcianfagna.
+- DMS: Provided a recipe file to relay primary key and column type map information
 
 ## 2025/06/23 v0.0.36
 - Dependencies: Migrated from `zyp` to `tikray`. It's effectively the

--- a/cratedb_toolkit/cluster/core.py
+++ b/cratedb_toolkit/cluster/core.py
@@ -567,7 +567,11 @@ class StandaloneCluster(ClusterBase):
         elif source_url_obj.scheme.startswith("kinesis"):
             from cratedb_toolkit.io.kinesis.api import kinesis_relay
 
-            kinesis_relay(source_url_obj, target_url)
+            kinesis_relay(
+                source_url=source_url_obj,
+                target_url=target_url,
+                recipe=transformation,
+            )
             self._load_table_result = True
 
         elif source_url_obj.scheme in ["file+bson", "http+bson", "https+bson", "mongodb", "mongodb+srv"]:

--- a/cratedb_toolkit/io/kinesis/api.py
+++ b/cratedb_toolkit/io/kinesis/api.py
@@ -1,10 +1,26 @@
+import typing as t
+from pathlib import Path
+
 from boltons.urlutils import URL
 
+from cratedb_toolkit.io.kinesis.model import RecipeDefinition
 from cratedb_toolkit.io.kinesis.relay import KinesisRelay
 from cratedb_toolkit.util.data import asbool
 
+TransformationType = t.Union[Path, RecipeDefinition, None]
 
-def kinesis_relay(source_url: URL, target_url):
+
+def kinesis_relay(source_url: URL, target_url: str, recipe: TransformationType = None):
     once = asbool(source_url.query_params.get("once", "false"))
-    ka = KinesisRelay(str(source_url), target_url)
+
+    if recipe is None:
+        parsed_recipe = None
+    elif isinstance(recipe, RecipeDefinition):
+        parsed_recipe = recipe
+    elif isinstance(recipe, Path):
+        parsed_recipe = RecipeDefinition.from_yaml(recipe.read_text())
+    else:
+        raise TypeError(f"Unsupported recipe type: {type(recipe)}")
+
+    ka = KinesisRelay(str(source_url), target_url, recipe=parsed_recipe)
     ka.start(once=once)

--- a/cratedb_toolkit/io/kinesis/model.py
+++ b/cratedb_toolkit/io/kinesis/model.py
@@ -1,0 +1,49 @@
+import typing as t
+
+from attr import Factory
+from attrs import define
+from commons_codec.model import ColumnType, ColumnTypeMapStore, PrimaryKeyStore, TableAddress
+from tikray.model.base import SchemaDefinition
+from tikray.model.collection import CollectionAddress
+from tikray.model.project import ProjectTransformation
+
+from cratedb_toolkit.util.config import Dumpable
+
+
+@define
+class ColumnTypeDefinition(SchemaDefinition):
+    pass
+
+
+@define
+class PrimaryKeyDefinition(SchemaDefinition):
+    @property
+    def names(self):
+        return [rule.pointer.lstrip("/") for rule in self.rules]
+
+
+@define
+class CollectionDefinition(Dumpable):
+    address: t.Union[CollectionAddress, None] = None
+    pk: t.Union[PrimaryKeyDefinition, None] = None
+    map: t.Union[ColumnTypeDefinition, None] = None
+
+
+@define
+class RecipeDefinition(ProjectTransformation):
+    collections: t.List[CollectionDefinition] = Factory(list)
+    _map: t.Dict[CollectionAddress, CollectionDefinition] = Factory(dict)
+
+    def codec_options(self) -> t.Tuple[PrimaryKeyStore, ColumnTypeMapStore]:
+        pks = PrimaryKeyStore()
+        cms = ColumnTypeMapStore()
+        for collection in self.collections:
+            if not collection.address:
+                continue
+            ta = TableAddress(schema=collection.address.container, table=collection.address.name)
+            if collection.pk:
+                pks[ta] = collection.pk.names
+            if collection.map:
+                for item in collection.map.rules:
+                    cms.add(ta, item.pointer.lstrip("/"), ColumnType(item.type))
+        return pks, cms

--- a/cratedb_toolkit/io/kinesis/model.py
+++ b/cratedb_toolkit/io/kinesis/model.py
@@ -11,6 +11,11 @@ from cratedb_toolkit.util.config import Dumpable
 
 
 @define
+class SettingsDefinition:
+    ignore_ddl: bool = True
+
+
+@define
 class ColumnTypeDefinition(SchemaDefinition):
     pass
 
@@ -25,6 +30,7 @@ class PrimaryKeyDefinition(SchemaDefinition):
 @define
 class CollectionDefinition(Dumpable):
     address: t.Union[CollectionAddress, None] = None
+    settings: t.Union[SettingsDefinition, None] = None
     pk: t.Union[PrimaryKeyDefinition, None] = None
     map: t.Union[ColumnTypeDefinition, None] = None
 

--- a/cratedb_toolkit/io/kinesis/model.py
+++ b/cratedb_toolkit/io/kinesis/model.py
@@ -23,7 +23,7 @@ class ColumnTypeDefinition(SchemaDefinition):
 @define
 class PrimaryKeyDefinition(SchemaDefinition):
     @property
-    def names(self):
+    def names(self) -> t.List[str]:
         return [rule.pointer.lstrip("/") for rule in self.rules]
 
 
@@ -38,7 +38,6 @@ class CollectionDefinition(Dumpable):
 @define
 class RecipeDefinition(ProjectTransformation):
     collections: t.List[CollectionDefinition] = Factory(list)
-    _map: t.Dict[CollectionAddress, CollectionDefinition] = Factory(dict)
 
     def codec_options(self) -> t.Tuple[PrimaryKeyStore, ColumnTypeMapStore]:
         pks = PrimaryKeyStore()

--- a/cratedb_toolkit/io/kinesis/relay.py
+++ b/cratedb_toolkit/io/kinesis/relay.py
@@ -4,6 +4,7 @@ import logging
 import typing as t
 
 import sqlalchemy as sa
+from commons_codec.model import SkipOperation
 from commons_codec.transform.aws_dms import DMSTranslatorCrateDB
 from commons_codec.transform.dynamodb import DynamoDBCDCTranslator
 from tqdm import tqdm
@@ -101,6 +102,8 @@ class KinesisRelay:
 
         try:
             operation = self.translator.to_sql(record)
+        except SkipOperation:
+            return
         except Exception:
             logger.exception("Translating CDC event to SQL failed")
             return

--- a/cratedb_toolkit/io/kinesis/relay.py
+++ b/cratedb_toolkit/io/kinesis/relay.py
@@ -45,10 +45,12 @@ class KinesisRelay:
             self.cratedb_table = self.cratedb_adapter.quote_relation_name(cratedb_table_name)
             self.translator = DynamoDBCDCTranslator(table_name=self.cratedb_table)
         elif self.kinesis_url.scheme == "kinesis+dms":
-            pks, cms = None, None
+            pks, cms, mapping_strategy, ignore_ddl = None, None, None, None
             if self.recipe:
-                pks, cms = self.recipe.codec_options()
-            self.translator = DMSTranslatorCrateDB(primary_keys=pks, column_types=cms)
+                pks, cms, mapping_strategy, ignore_ddl = self.recipe.codec_options()
+            self.translator = DMSTranslatorCrateDB(
+                primary_keys=pks, column_types=cms, mapping_strategy=mapping_strategy, ignore_ddl=ignore_ddl
+            )
         else:
             raise NotImplementedError(f"Data processing not implemented for {self.kinesis_url}")
 

--- a/doc/io/dms/standalone.md
+++ b/doc/io/dms/standalone.md
@@ -42,6 +42,38 @@ In general, if your `~/.aws/config` and `~/.aws/credentials` file are populated 
 because you are using awscli or boto3 successfully, you should be ready to go.
 :::
 
+## Configuration
+
+You can configure the processor element by using a recipe file, to be conveyed through
+the `--transformation` CLI option, like so:
+```shell
+ctk load table \
+  "kinesis+dms:///arn:aws:kinesis:eu-central-1:831394476016:stream/testdrive" \
+  --transformation=dms-load-schema.yaml
+```
+
+The recipe file can be used to define primary key information and column type
+mapping rules.
+```yaml
+# Recipe file for digesting DMS events.
+# https://cratedb-toolkit.readthedocs.io/io/dms/standalone.html
+---
+meta:
+  type: tikray-projecta
+  version: 1
+collections:
+- address:
+    container: public
+    name: foobar
+  pk:
+    rules:
+    - pointer: /id
+      type: bigint
+  map:
+    rules:
+    - pointer: /resource
+      type: map
+```
 
 
 [AWS DMS]: https://aws.amazon.com/dms/

--- a/doc/io/dms/standalone.md
+++ b/doc/io/dms/standalone.md
@@ -49,23 +49,33 @@ the `--transformation` CLI option, like so:
 ```shell
 ctk load table \
   "kinesis+dms:///arn:aws:kinesis:eu-central-1:831394476016:stream/testdrive" \
-  --transformation=dms-load-schema.yaml
+  --transformation=dms-load-schema-universal.yaml
 ```
 
-The recipe file can be used to define settings, primary key information, and
-column type mapping rules.
+The recipe file can be used to define settings, primary key information, the column
+mapping strategy, and column type mapping rules.
+
+If you want to provide the SQL DDL manually, please toggle `settings.ignore_ddl: true`,
+and provide the primary key information per `pk` instead.
+
+When the data includes container types, for example originating from JSON(B) columns,
+use the `map` section to assign column type information to them.
+
+If your columns include names with leading underscores, you may need to resort
+to the `settings.mapping_strategy: universal` setting.
 ```yaml
 # Recipe file for digesting DMS events.
 # https://cratedb-toolkit.readthedocs.io/io/dms/standalone.html
 ---
 meta:
-  type: tikray-projecta
+  type: tikray-project
   version: 1
 collections:
 - address:
     container: public
     name: foobar
   settings:
+    mapping_strategy: direct
     ignore_ddl: true
   pk:
     rules:
@@ -74,7 +84,7 @@ collections:
   map:
     rules:
     - pointer: /resource
-      type: map
+      type: object
 ```
 
 

--- a/doc/io/dms/standalone.md
+++ b/doc/io/dms/standalone.md
@@ -52,8 +52,8 @@ ctk load table \
   --transformation=dms-load-schema.yaml
 ```
 
-The recipe file can be used to define primary key information and column type
-mapping rules.
+The recipe file can be used to define settings, primary key information, and
+column type mapping rules.
 ```yaml
 # Recipe file for digesting DMS events.
 # https://cratedb-toolkit.readthedocs.io/io/dms/standalone.html
@@ -65,6 +65,8 @@ collections:
 - address:
     container: public
     name: foobar
+  settings:
+    ignore_ddl: true
   pk:
     rules:
     - pointer: /id

--- a/examples/cdc/aws/dms-control-create-table.json
+++ b/examples/cdc/aws/dms-control-create-table.json
@@ -1,0 +1,25 @@
+{
+  "control": {
+    "table-def": {
+      "columns": {
+        "rowid": {
+          "type": "INT64",
+          "nullable": false
+        },
+        "resource": {
+          "type": "TEXT",
+          "nullable": true
+        }
+      }
+    }
+  },
+  "metadata": {
+    "timestamp": "2025-06-21T12:06:51.287587Z",
+    "record-type": "control",
+    "operation": "create-table",
+    "partition-key-type": "task-id",
+    "partition-key-value": "DZ6OKLFYA5BWVG4RYROQUHXU4E",
+    "schema-name": "testdrive-data",
+    "table-name": "foobar"
+  }
+}

--- a/examples/cdc/aws/dms-data-load.json
+++ b/examples/cdc/aws/dms-data-load.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "rowid": 1,
+    "resource": "{\"temperature\": 42.42}"
+  },
+  "metadata": {
+    "timestamp": "2025-06-21T12:06:51.175136Z",
+    "record-type": "data",
+    "operation": "load",
+    "partition-key-type": "schema-table",
+    "schema-name": "testdrive-data",
+    "table-name": "foobar"
+  }
+}

--- a/examples/cdc/aws/dms-load-schema-direct-noddl.yaml
+++ b/examples/cdc/aws/dms-load-schema-direct-noddl.yaml
@@ -1,0 +1,21 @@
+# Recipe file for digesting DMS events.
+# https://cratedb-toolkit.readthedocs.io/io/dms/standalone.html
+---
+meta:
+  type: dms-recipe
+  version: 1
+collections:
+- address:
+    container: testdrive-data
+    name: foobar
+  settings:
+    mapping_strategy: direct
+    ignore_ddl: true
+  pk:
+    rules:
+    - pointer: /rowid
+      type: bigint
+  map:
+    rules:
+    - pointer: /resource
+      type: map

--- a/examples/cdc/aws/dms-load-schema-direct.yaml
+++ b/examples/cdc/aws/dms-load-schema-direct.yaml
@@ -1,0 +1,12 @@
+# Recipe file for digesting DMS events.
+# https://cratedb-toolkit.readthedocs.io/io/dms/standalone.html
+---
+meta:
+  type: dms-recipe
+  version: 1
+collections:
+- address:
+    container: testdrive-data
+    name: foobar
+  settings:
+    mapping_strategy: direct

--- a/examples/cdc/aws/dms-load-schema-universal-noddl.yaml
+++ b/examples/cdc/aws/dms-load-schema-universal-noddl.yaml
@@ -2,13 +2,14 @@
 # https://cratedb-toolkit.readthedocs.io/io/dms/standalone.html
 ---
 meta:
-  type: tikray-projecta
+  type: dms-recipe
   version: 1
 collections:
 - address:
     container: testdrive-data
     name: foobar
   settings:
+    mapping_strategy: universal
     ignore_ddl: true
   pk:
     rules:

--- a/examples/cdc/aws/dms-load-schema-universal.yaml
+++ b/examples/cdc/aws/dms-load-schema-universal.yaml
@@ -1,0 +1,12 @@
+# Recipe file for digesting DMS events.
+# https://cratedb-toolkit.readthedocs.io/io/dms/standalone.html
+---
+meta:
+  type: dms-recipe
+  version: 1
+collections:
+- address:
+    container: testdrive
+    name: demo
+  settings:
+    mapping_strategy: universal

--- a/examples/cdc/aws/dms-load-schema.yaml
+++ b/examples/cdc/aws/dms-load-schema.yaml
@@ -1,0 +1,18 @@
+# Recipe file for digesting DMS events.
+# https://cratedb-toolkit.readthedocs.io/io/dms/standalone.html
+---
+meta:
+  type: tikray-projecta
+  version: 1
+collections:
+- address:
+    container: testdrive-data
+    name: foobar
+  pk:
+    rules:
+    - pointer: /rowid
+      type: bigint
+  map:
+    rules:
+    - pointer: /resource
+      type: map

--- a/examples/cdc/aws/dms-load-schema.yaml
+++ b/examples/cdc/aws/dms-load-schema.yaml
@@ -8,6 +8,8 @@ collections:
 - address:
     container: testdrive-data
     name: foobar
+  settings:
+    ignore_ddl: true
   pk:
     rules:
     - pointer: /rowid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ optional-dependencies.kinesis = [
   "aiobotocore<2.24",
   "async-kinesis<3",
   "botocore<1.39",
-  "commons-codec>=0.0.23",
+  "commons-codec @ git+https://github.com/crate/commons-codec@dms-no-ddl",
   "cratedb-toolkit[io-recipe]",
   "lorrystream[carabas]>=0.0.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ optional-dependencies.kinesis = [
   "aiobotocore<2.24",
   "async-kinesis<3",
   "botocore<1.39",
-  "commons-codec @ git+https://github.com/crate/commons-codec@dms-no-ddl",
+  "commons-codec @ git+https://github.com/crate/commons-codec@dms-direct-mapping",
   "cratedb-toolkit[io-recipe]",
   "lorrystream[carabas]>=0.0.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ optional-dependencies.kinesis = [
   "aiobotocore<2.24",
   "async-kinesis<3",
   "botocore<1.39",
-  "commons-codec @ git+https://github.com/crate/commons-codec@dms-direct-mapping",
+  "commons-codec>=0.0.24",
   "cratedb-toolkit[io-recipe]",
   "lorrystream[carabas]>=0.0.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ optional-dependencies.docs-api = [
 optional-dependencies.dynamodb = [
   "boto3",
   "commons-codec>=0.0.20",
+  "cratedb-toolkit[io-recipe]",
 ]
 optional-dependencies.full = [
   "cratedb-toolkit[cfr,datasets,docs-api,io,mcp,service]",
@@ -176,11 +177,15 @@ optional-dependencies.io = [
   "sqlalchemy>=2",
   "universal-pathlib<0.3",
 ]
+optional-dependencies.io-recipe = [
+  "tikray>=0.2,<0.3",
+]
 optional-dependencies.kinesis = [
   "aiobotocore<2.24",
   "async-kinesis<3",
   "botocore<1.39",
   "commons-codec>=0.0.23",
+  "cratedb-toolkit[io-recipe]",
   "lorrystream[carabas]>=0.0.6",
 ]
 optional-dependencies.mcp = [
@@ -188,12 +193,11 @@ optional-dependencies.mcp = [
 ]
 optional-dependencies.mongodb = [
   "commons-codec[mongodb]>=0.0.22",
-  "cratedb-toolkit[io]",
+  "cratedb-toolkit[io,io-recipe]",
   "orjson>=3.3.1,<4",
   "pymongo>=3.10.1,<4.10",
   "python-bsonjs<0.7",
   "rich>=3.3.2,<15",
-  "tikray>=0.2,<0.3",
   "undatum<1.1",
 ]
 optional-dependencies.pymongo = [

--- a/tests/io/kinesis/test_cli.py
+++ b/tests/io/kinesis/test_cli.py
@@ -100,9 +100,10 @@ def test_kinesis_dms_load_without_ddl(caplog, tmp_path, cratedb):
     transformation_file = Path("./examples/cdc/aws/dms-load-schema.yaml")
 
     # Write a single event as a dump file to disk.
+    dms_ddl_event = json.loads(Path("./examples/cdc/aws/dms-control-create-table.json").read_text())
     dms_load_event = json.loads(Path("./examples/cdc/aws/dms-data-load.json").read_text())
     stream_dump_file = tmp_path / "dms-load.ndjson"
-    orjsonl.save(stream_dump_file, [dms_load_event])
+    orjsonl.save(stream_dump_file, [dms_ddl_event, dms_load_event])
 
     # Define source and target URLs.
     kinesis_url = f"kinesis+dms://{stream_dump_file.absolute()}"

--- a/tests/io/kinesis/test_cli.py
+++ b/tests/io/kinesis/test_cli.py
@@ -1,5 +1,7 @@
+import json
 from pathlib import Path
 
+import orjsonl
 import pytest
 from click.testing import CliRunner
 
@@ -75,3 +77,49 @@ def test_kinesis_dms_file(caplog, cratedb):
     assert cratedb.database.count_records("testdrive.diamonds") == 5
     assert cratedb.database.count_records("testdrive.functional_alltypes") == 5
     assert cratedb.database.count_records("testdrive.win") == 5
+
+
+def test_kinesis_dms_load_without_ddl(caplog, tmp_path, cratedb):
+    """
+    CLI test: Invoke `ctk load table` for DMS over Kinesis with a pre-defined target schema.
+
+    While this variant doesn't need a DDL, it needs to be supplied with
+    primary key and column type information manually.
+    """
+
+    # Supply SQL DDL manually.
+    cratedb.database.run_sql(
+        'CREATE TABLE "testdrive-data".foobar '
+        "(pk OBJECT(STRICT) AS (rowid BIGINT), "
+        "data OBJECT(DYNAMIC), "
+        "aux OBJECT(IGNORED))",
+        records=True,
+    )
+
+    # Define transformation file.
+    transformation_file = Path("./examples/cdc/aws/dms-load-schema.yaml")
+
+    # Write a single event as a dump file to disk.
+    dms_load_event = json.loads(Path("./examples/cdc/aws/dms-data-load.json").read_text())
+    stream_dump_file = tmp_path / "dms-load.ndjson"
+    orjsonl.save(stream_dump_file, [dms_load_event])
+
+    # Define source and target URLs.
+    kinesis_url = f"kinesis+dms://{stream_dump_file.absolute()}"
+    cratedb_url = f"{cratedb.get_connection_url()}/testdrive-data"
+
+    # Run transfer command.
+    runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb_url})
+    result = runner.invoke(
+        cli,
+        args=f"load table {kinesis_url} --transformation='{transformation_file}'",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Verify data in target database.
+    assert cratedb.database.table_exists("testdrive-data.foobar") is True
+    assert cratedb.database.refresh_table("testdrive-data.foobar") is True
+    assert cratedb.database.count_records("testdrive-data.foobar") == 1
+    data = cratedb.database.run_sql('SELECT * FROM "testdrive-data".foobar', records=True)
+    assert data == [{"pk": {"rowid": 1}, "data": {"resource": {"temperature": 42.42}}, "aux": {}}]

--- a/tests/io/kinesis/test_cli.py
+++ b/tests/io/kinesis/test_cli.py
@@ -11,10 +11,53 @@ from tests.io.kinesis.data import DMS_CDC_CREATE_TABLE, DMS_CDC_INSERT_BASIC
 pytestmark = pytest.mark.kinesis
 
 
-def test_kinesis_dms_stream(caplog, cratedb, kinesis, kinesis_test_manager):
+def test_kinesis_dms_stream_universal(caplog, cratedb, kinesis, kinesis_test_manager):
     """
-    CLI test: Invoke `ctk load table` for DMS over Kinesis from a stream.
+    CLI test: Invoke `ctk load table` for DMS over Kinesis from a stream, using universal mapping strategy.
     """
+
+    # Define transformation file.
+    transformation_file = Path("./examples/cdc/aws/dms-load-schema-universal.yaml")
+
+    # Define source and target URLs.
+    kinesis_url = (
+        f"{kinesis.get_connection_url_kinesis()}?region=us-east-1"
+        f"&buffer-time=0.01&idle-sleep=0.01&create=true&once=true"
+    )
+    cratedb_url = f"{cratedb.get_connection_url()}/testdrive"
+
+    # Populate source stream with sample dataset.
+    # Define two CDC events: CREATE TABLE and INSERT.
+    events = [
+        DMS_CDC_CREATE_TABLE,
+        DMS_CDC_INSERT_BASIC,
+    ]
+    kinesis_test_manager.load_events(events)
+
+    # Run transfer command.
+    runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb_url})
+    result = runner.invoke(
+        cli,
+        args=f"load table {kinesis_url} --transformation='{transformation_file}'",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Verify data in target database.
+    assert cratedb.database.table_exists("testdrive.demo") is True
+    assert cratedb.database.refresh_table("testdrive.demo") is True
+    assert cratedb.database.count_records("testdrive.demo") == 1
+    data = cratedb.database.run_sql('SELECT * FROM "testdrive".demo', records=True)
+    assert data == [{"pk": {"id": 393}, "data": {"name": "Test", "attributes": None, "age": 4}, "aux": {}}]
+
+
+def test_kinesis_dms_stream_direct(caplog, cratedb, kinesis, kinesis_test_manager):
+    """
+    CLI test: Invoke `ctk load table` for DMS over Kinesis from a stream, using direct mapping strategy.
+    """
+
+    # Define transformation file.
+    transformation_file = Path("./examples/cdc/aws/dms-load-schema-direct.yaml")
 
     # Define source and target URLs.
     kinesis_url = f"{kinesis.get_connection_url_kinesis()}?region=us-east-1&create=true&once=true"
@@ -32,7 +75,7 @@ def test_kinesis_dms_stream(caplog, cratedb, kinesis, kinesis_test_manager):
     runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb_url})
     result = runner.invoke(
         cli,
-        args=f"load table {kinesis_url}",
+        args=f"load table {kinesis_url} --transformation='{transformation_file}'",
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -41,9 +84,11 @@ def test_kinesis_dms_stream(caplog, cratedb, kinesis, kinesis_test_manager):
     assert cratedb.database.table_exists("testdrive.demo") is True
     assert cratedb.database.refresh_table("testdrive.demo") is True
     assert cratedb.database.count_records("testdrive.demo") == 1
+    data = cratedb.database.run_sql('SELECT * FROM "testdrive".demo', records=True)
+    assert data == [{"id": 393, "name": "Test", "attributes": None, "age": 4}]
 
 
-def test_kinesis_dms_file(caplog, cratedb):
+def test_kinesis_dms_file_universal(caplog, cratedb):
     """
     CLI test: Invoke `ctk load table` for DMS over Kinesis from a dump file.
     """
@@ -79,9 +124,9 @@ def test_kinesis_dms_file(caplog, cratedb):
     assert cratedb.database.count_records("testdrive.win") == 5
 
 
-def test_kinesis_dms_load_without_ddl(caplog, tmp_path, cratedb):
+def test_kinesis_dms_load_without_ddl_universal(caplog, tmp_path, cratedb):
     """
-    CLI test: Invoke `ctk load table` for DMS over Kinesis with a pre-defined target schema.
+    Validate DMS over Kinesis with a pre-defined target schema, using the universal mapping.
 
     While this variant doesn't need a DDL, it needs to be supplied with
     primary key and column type information manually.
@@ -90,20 +135,19 @@ def test_kinesis_dms_load_without_ddl(caplog, tmp_path, cratedb):
     # Supply SQL DDL manually.
     cratedb.database.run_sql(
         'CREATE TABLE "testdrive-data".foobar '
-        "(pk OBJECT(STRICT) AS (rowid BIGINT), "
+        "(pk OBJECT(STRICT) AS (rowid BIGINT PRIMARY KEY), "
         "data OBJECT(DYNAMIC), "
         "aux OBJECT(IGNORED))",
         records=True,
     )
 
     # Define transformation file.
-    transformation_file = Path("./examples/cdc/aws/dms-load-schema.yaml")
+    transformation_file = Path("./examples/cdc/aws/dms-load-schema-universal-noddl.yaml")
 
     # Write a single event as a dump file to disk.
-    dms_ddl_event = json.loads(Path("./examples/cdc/aws/dms-control-create-table.json").read_text())
     dms_load_event = json.loads(Path("./examples/cdc/aws/dms-data-load.json").read_text())
     stream_dump_file = tmp_path / "dms-load.ndjson"
-    orjsonl.save(stream_dump_file, [dms_ddl_event, dms_load_event])
+    orjsonl.save(stream_dump_file, [dms_load_event])
 
     # Define source and target URLs.
     kinesis_url = f"kinesis+dms://{stream_dump_file.absolute()}"
@@ -124,3 +168,46 @@ def test_kinesis_dms_load_without_ddl(caplog, tmp_path, cratedb):
     assert cratedb.database.count_records("testdrive-data.foobar") == 1
     data = cratedb.database.run_sql('SELECT * FROM "testdrive-data".foobar', records=True)
     assert data == [{"pk": {"rowid": 1}, "data": {"resource": {"temperature": 42.42}}, "aux": {}}]
+
+
+def test_kinesis_dms_load_without_ddl_direct(caplog, tmp_path, cratedb):
+    """
+    Validate DMS over Kinesis with a pre-defined target schema, using the direct mapping.
+
+    While this variant doesn't need a DDL, it needs to be supplied with
+    primary key and column type information manually.
+    """
+
+    # Supply SQL DDL manually.
+    cratedb.database.run_sql(
+        'CREATE TABLE "testdrive-data".foobar (rowid BIGINT PRIMARY KEY, resource OBJECT(DYNAMIC))',
+        records=True,
+    )
+
+    # Define transformation file.
+    transformation_file = Path("./examples/cdc/aws/dms-load-schema-direct-noddl.yaml")
+
+    # Write a single event as a dump file to disk.
+    dms_load_event = json.loads(Path("./examples/cdc/aws/dms-data-load.json").read_text())
+    stream_dump_file = tmp_path / "dms-load.ndjson"
+    orjsonl.save(stream_dump_file, [dms_load_event])
+
+    # Define source and target URLs.
+    kinesis_url = f"kinesis+dms://{stream_dump_file.absolute()}"
+    cratedb_url = f"{cratedb.get_connection_url()}/testdrive-data"
+
+    # Run transfer command.
+    runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb_url})
+    result = runner.invoke(
+        cli,
+        args=f"load table {kinesis_url} --transformation='{transformation_file}'",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Verify data in target database.
+    assert cratedb.database.table_exists("testdrive-data.foobar") is True
+    assert cratedb.database.refresh_table("testdrive-data.foobar") is True
+    assert cratedb.database.count_records("testdrive-data.foobar") == 1
+    data = cratedb.database.run_sql('SELECT * FROM "testdrive-data".foobar', records=True)
+    assert data == [{"rowid": 1, "resource": {"temperature": 42.42}}]

--- a/tests/io/kinesis/test_relay.py
+++ b/tests/io/kinesis/test_relay.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 import pytest
 
+from cratedb_toolkit.io.kinesis.model import RecipeDefinition
 from cratedb_toolkit.io.kinesis.relay import KinesisRelay
 from tests.io.kinesis.data import DMS_CDC_CREATE_TABLE, DMS_CDC_INSERT_BASIC
 from tests.io.test_processor import wrap_kinesis
@@ -9,7 +12,7 @@ pytestmark = pytest.mark.kinesis
 pytest.importorskip("commons_codec", reason="Only works with commons-codec installed")
 
 
-def test_kinesis_earliest_dms_cdc_ddl_dml(caplog, cratedb, kinesis):
+def test_kinesis_earliest_dms_cdc_ddl_dml_universal(caplog, cratedb, kinesis):
     """
     Roughly verify that the AWS DynamoDB CDC processing through Kinesis works as expected.
 
@@ -29,8 +32,12 @@ def test_kinesis_earliest_dms_cdc_ddl_dml(caplog, cratedb, kinesis):
         wrap_kinesis(DMS_CDC_INSERT_BASIC),
     ]
 
+    # Define transformation file.
+    transformation_file = Path("./examples/cdc/aws/dms-load-schema-universal.yaml")
+
     # Initialize table loader.
-    table_loader = KinesisRelay(kinesis_url=kinesis_url, cratedb_url=cratedb_url)
+    recipe = RecipeDefinition.from_yaml(transformation_file.read_text())
+    table_loader = KinesisRelay(kinesis_url=kinesis_url, cratedb_url=cratedb_url, recipe=recipe)
 
     # Populate the Kinesis stream with data.
     for event in events:

--- a/tests/meta/test_release.py
+++ b/tests/meta/test_release.py
@@ -1,34 +1,30 @@
+from verlib2 import Version
+
 from cratedb_toolkit.meta.release import CrateDBRelease
 
 
 def test_release_stable():
     cr = CrateDBRelease()
     assert cr.stable.category == "stable"
-    assert cr.stable.version >= "5.10.5"
+    assert Version(cr.stable.version) >= Version("5.10.5")
     assert cr.stable.date >= "2025-04-30"
     assert cr.stable.type == "tarball"
-    assert cr.stable.url >= "https://cdn.crate.io/downloads/releases/crate-5.10.5.tar.gz"
     assert cr.stable.cloud_version.startswith("stable-")
-    assert cr.stable.cloud_version >= "stable-5.10.5"
 
 
 def test_release_testing():
     cr = CrateDBRelease()
     assert cr.testing.category == "testing"
-    assert cr.testing.version >= "5.10.5"
+    assert Version(cr.testing.version) >= Version("5.10.5")
     assert cr.testing.date >= "2025-04-28"
     assert cr.testing.type == "tarball"
-    assert cr.testing.url >= "https://cdn.crate.io/downloads/releases/crate-5.10.5.tar.gz"
     assert cr.testing.cloud_version.startswith("testing-")
-    assert cr.testing.cloud_version >= "testing-5.10.5"
 
 
 def test_release_nightly():
     cr = CrateDBRelease()
     assert cr.nightly.category == "nightly"
-    assert cr.nightly.version >= "6.0.0"
+    assert Version(cr.nightly.version) >= Version("6.0.0")
     assert cr.nightly.date >= "2025-05-01"
     assert cr.nightly.type == "tarball"
-    assert cr.nightly.url >= "https://cdn.crate.io/downloads/releases/crate-5.10.5.tar.gz"
     assert cr.nightly.cloud_version.startswith("nightly-")
-    assert cr.nightly.cloud_version >= "nightly-6.0.0-2025-05-01-00-02"


### PR DESCRIPTION
## About

Giving the DMS nozzle a way to accept settings and parameters, for example to relay primary key and column type map information.

## Preview

```
uv tool install --upgrade 'cratedb-toolkit[kinesis] @ git+https://github.com/crate/cratedb-toolkit@dms-refinements'
```

## Documentation

https://cratedb-toolkit--469.org.readthedocs.build/io/dms/standalone.html#configuration

## Poetry

In the warren of code, a recipe appears,
Mapping keys and columns, allaying schema fears.
Through Kinesis it flows, to CrateDB’s delight,
With YAML and JSON, our tables set right.
Now rabbits can test, and users can see—
Transformation made simple, as easy as can be!
🐇✨
