### PR TITLE
Dependencies: Update to `async-kinesis>=2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,7 @@ optional-dependencies.io-recipe = [
 ]
 optional-dependencies.kinesis = [
   "aiobotocore<2.24",
-  "async-kinesis<3",
+  "async-kinesis>=2,<3",
   "botocore<1.39",
   "commons-codec>=0.0.24",
   "cratedb-toolkit[io-recipe]",


### PR DESCRIPTION
## About

> Could we consider bumping the dependency to `async-kinesis>2,<3 `? It would have the advantage of the documented example being guaranteed to work.
