### PR TITLE
Chore: Fix `mypy` type checking by downgrading `types-docutils`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ optional-dependencies.test = [
   "pydantic-core<3",
   "responses<0.26",
   "testcontainers[azurite,localstack,minio,postgres]",
+  "types-docutils>=0.20.0.20240106,<0.21.0.20250708",
 ]
 optional-dependencies.test-mongodb = [
   "cratedb-toolkit[test]",


### PR DESCRIPTION
What the title says.