### PR TITLE
Dependencies (PyMongo): Fix error with NumPy 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ optional-dependencies.mongodb = [
 ]
 optional-dependencies.pymongo = [
   "jessiql==1.0.0rc1",
+  "numpy<2",
   "pandas<2.2",
   "pymongo<4.9",
   "sqlalchemy<2",


### PR DESCRIPTION
## Problem
```python
ValueError: numpy.dtype size changed, may indicate binary incompatibility.
```
On this error, it is advisable to downgrade to NumPy 1.x.

## References
- https://github.com/daq-tools/skeem/issues/112
- https://github.com/crate/cratedb-toolkit/actions/runs/16666701610/job/47174409619?pr=493#step:7:46
