### PR TITLE
Chore: Remove Python 3.10 from compatibility support for Kinesis nozzle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,7 +322,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: [
-          "3.10",
+          "3.11",
           "3.13",
         ]
 


### PR DESCRIPTION
## Problem

Recent CI runs suddenly produced this error.

-- https://github.com/crate/cratedb-toolkit/actions/runs/16951193121/job/48044132939?pr=500#step:7:39