### PR TITLE
I/O: Tune down ingestr, it masked native I/O adapters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - CFR: Improved importing data re. type mapping without NumPy
 - CFR: Truncated target table before importing, using `append`
   strategy again, because `replace` doesn't do the right DDL.
+- I/O: Tuned down ingestr, it masked native I/O adapters
 
 ## 2025/07/01 v0.0.37
 - Settings: Fixed comparison of `0s` vs `0ms`. Thanks, @hlcianfagna.

--- a/cratedb_toolkit/cluster/core.py
+++ b/cratedb_toolkit/cluster/core.py
@@ -540,14 +540,7 @@ class StandaloneCluster(ClusterBase):
         target_url = self.address.dburi
         source_url_obj = URL(source.url)
 
-        if ingestr_select(source_url):
-            if ingestr_copy(source_url, self.address, progress=True):
-                self._load_table_result = True
-            else:
-                logger.error("Data loading failed or incomplete")
-                self._load_table_result = False
-
-        elif source_url_obj.scheme.startswith("dynamodb"):
+        if source_url_obj.scheme.startswith("dynamodb"):
             from cratedb_toolkit.io.dynamodb.api import dynamodb_copy
 
             if dynamodb_copy(str(source_url_obj), target_url, progress=True):
@@ -605,6 +598,13 @@ class StandaloneCluster(ClusterBase):
                 else:
                     logger.error("Data loading failed or incomplete")
                     self._load_table_result = False
+
+        elif ingestr_select(source_url):
+            if ingestr_copy(source_url, self.address, progress=True):
+                self._load_table_result = True
+            else:
+                logger.error("Data loading failed or incomplete")
+                self._load_table_result = False
 
         else:
             raise NotImplementedError(f"Importing resource not implemented yet: {source_url_obj}")


### PR DESCRIPTION
## Problem

Through a report by Võ Thiện, we found out the ingestr-based data nozzle was masking the existing native I/O adapters. This patch aims to fix it.

-- https://community.cratedb.com/t/using-ctk-ingestr-to-sync-mongodb-with-cratedb/2062