### PR TITLE
Ingestr: Remove "MongoDB to CrateDB" advice

### DIFF
--- a/doc/io/ingestr/index.md
+++ b/doc/io/ingestr/index.md
@@ -324,13 +324,6 @@ ctk load table \
 See [HubSpot entities] about any labels you can use for the `table` parameter
 in the source URL.
 
-### MongoDB to CrateDB
-```shell
-ctk load table \
-    "mongodb://<username>:<password>@<hostname>:<port>/?table=<database>.<collection>" \
-    --cluster-url="crate://crate:na@localhost:4200/testdrive/mongodb_demo"
-```
-
 ### MySQL to CrateDB
 ```shell
 ctk load table \


### PR DESCRIPTION
## Why?
It is better handled by the built-in native I/O adapter.

## References
- https://community.cratedb.com/t/using-ctk-ingestr-to-sync-mongodb-with-cratedb/2062