### PR TITLE
I/O: Fix MongoDB CDC invocation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- I/O: Fixed MongoDB CDC invocation. Thanks, Mỹ Duyên.
 
 ## 2025/08/19 v0.0.39
 - OCI: Started producing image `ghcr.io/crate/cratedb-toolkit-ingest`

--- a/cratedb_toolkit/cluster/core.py
+++ b/cratedb_toolkit/cluster/core.py
@@ -574,7 +574,15 @@ class StandaloneCluster(ClusterBase):
             )
             self._load_table_result = True
 
-        elif source_url_obj.scheme in ["file+bson", "http+bson", "https+bson", "mongodb", "mongodb+srv"]:
+        elif source_url_obj.scheme in [
+            "file+bson",
+            "http+bson",
+            "https+bson",
+            "mongodb",
+            "mongodb+srv",
+            "mongodb+cdc",
+            "mongodb+srv+cdc",
+        ]:
             if "+cdc" in source_url_obj.scheme:
                 source_url_obj.scheme = source_url_obj.scheme.replace("+cdc", "")
 


### PR DESCRIPTION
## About

Users [reported](https://community.cratedb.com/t/enumerating-options-to-sync-collections-from-mongodb/2069/3) that MongoDB CDC wasn't working. This patch fixes it.