### PR TITLE
I/O: Update to `influxio-0.6.0`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 - I/O: Updated to `influxio-0.6.0`. Thanks, @ZillKhan.
-  - From now on, the target table will be the measurement name when
-    importing ILP files.
-  - The InfluxDB source URL now accepts the `timeout` query parameter
-    to configure the network timeout in seconds when talking to the
-    InfluxDB API.
+  - The target table is now the measurement name when importing ILP files.
+  - The InfluxDB source URL accepts a `timeout` query parameter (seconds) to
+    configure the network timeout when talking to the InfluxDB API.
+  - For ILP imports, the CrateDB URL no longer needs a table component;
+    you can point it at the schema only (the measurement determines the table).
 
 ## 2025/08/19 v0.0.40
 - I/O: Fixed MongoDB CDC invocation. Thanks, Mỹ Duyên.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- I/O: Updated to `influxio-0.6.0`. Thanks, @ZillKhan.
+  - From now on, the target table will be the measurement name when
+    importing ILP files.
+  - The InfluxDB source URL now accepts the `timeout` query parameter
+    to configure the network timeout in seconds when talking to the
+    InfluxDB API.
 
 ## 2025/08/19 v0.0.40
 - I/O: Fixed MongoDB CDC invocation. Thanks, Mỹ Duyên.

--- a/cratedb_toolkit/io/influxdb.py
+++ b/cratedb_toolkit/io/influxdb.py
@@ -2,8 +2,6 @@ import logging
 
 from influxio.core import copy
 
-from cratedb_toolkit.model import DatabaseAddress
-
 logger = logging.getLogger(__name__)
 
 
@@ -14,12 +12,6 @@ def influxdb_copy(source_url, target_url, progress: bool = False):
     export CRATEDB_CLUSTER_URL=crate://crate@localhost:4200/testdrive/demo
     ctk load table influxdb2://example:token@localhost:8086/testdrive/demo
     """
-
-    # Sanity checks.
-    target_address = DatabaseAddress.from_string(target_url)
-    url, table_address = target_address.decode()
-    if table_address.table is None:
-        raise ValueError("Table name is missing. Please adjust CrateDB database URL.")
 
     # Invoke copy operation.
     logger.info("Running InfluxDB copy")

--- a/doc/io/influxdb/loader.md
+++ b/doc/io/influxdb/loader.md
@@ -73,6 +73,11 @@ ctk load table \
     "https://github.com/influxdata/influxdb2-sample-data/raw/master/air-sensor-data/air-sensor-data.lp"
 ```
 
+:::{note}
+When importing from ILP files, the measurement name from the data file
+will be used as the target table name.
+:::
+
 ### Cloud
 
 A canonical invocation for copying data from InfluxDB Cloud to CrateDB Cloud.
@@ -85,7 +90,23 @@ ctk load table \
   --cluster-url="crate://admin:dZ...6LqB@green-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200/testdrive/demo?ssl=true"
 ```
 
-## Parameters
+## InfluxDB parameters
+
+### `timeout`
+
+The network timeout value is specified in seconds, the default value
+is 60 seconds. Both details deviate from the standard default setting
+of the underlying [InfluxDB client library][influxdb-client], which
+uses milliseconds, and a default value of 10_000 milliseconds.
+
+If you need to adjust this setting, add the parameter `timeout` to
+the InfluxDB URL like this:
+
+```shell
+ctk load table influxdb2://example:token@localhost:8086/testdrive/demo?timeout=300
+```
+
+## CrateDB parameters
 
 ### `if-exists`
 
@@ -107,4 +128,5 @@ ctk load table influxdb2://example:token@localhost:8086/testdrive/demo
 ```
 
 
+[influxdb-client]: https://github.com/influxdata/influxdb-client-python
 [influxio]: inv:influxio:*:label#index

--- a/doc/io/influxdb/loader.md
+++ b/doc/io/influxdb/loader.md
@@ -74,8 +74,9 @@ ctk load table \
 ```
 
 :::{note}
-When importing from ILP files, the measurement name from the data file
-will be used as the target table name.
+For ILP imports, the CrateDB connection URL can point to the schema only;
+any table component is ignored. Example:
+`export CRATEDB_CLUSTER_URL="crate://crate@localhost:4200/testdrive"`.
 :::
 
 ### Cloud
@@ -94,14 +95,11 @@ ctk load table \
 
 ### `timeout`
 
-The network timeout value is specified in seconds, the default value
-is 60 seconds. Both details deviate from the standard default setting
-of the underlying [InfluxDB client library][influxdb-client], which
-uses milliseconds, and a default value of 10_000 milliseconds.
+The network timeout is specified in seconds (default: 60). This deviates from
+the underlying [InfluxDB client library][influxdb-client], which uses
+milliseconds and a default of 10_000 ms.
 
-If you need to adjust this setting, add the parameter `timeout` to
-the InfluxDB URL like this:
-
+To adjust the timeout, add a `timeout` query parameter to the InfluxDB URL:
 ```shell
 ctk load table influxdb2://example:token@localhost:8086/testdrive/demo?timeout=300
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ optional-dependencies.full = [
 ]
 optional-dependencies.influxdb = [
   "cratedb-toolkit[io]",
-  "influxio>=0.5,<1",
+  "influxio>=0.6,<1",
 ]
 optional-dependencies.io = [
   "cratedb-toolkit[io-base]",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ RESET_TABLES = [
     f'"{TESTDRIVE_DATA_SCHEMA}"."foobar_unique_composite"',
     # cratedb_toolkit.io.{influxdb,mongodb}
     '"testdrive"."demo"',
+    '"testdrive"."ndbc"',
 ]
 
 CRATEDB_HTTP_PORT = 44209

--- a/tests/io/influxdb/test_cli.py
+++ b/tests/io/influxdb/test_cli.py
@@ -32,27 +32,9 @@ def test_line_protocol_load_table_success(caplog, cratedb, needs_sqlalchemy2):
     assert result.exit_code == 0
 
     # Verify data in target database.
-    assert cratedb.database.table_exists("testdrive.demo") is True
-    assert cratedb.database.refresh_table("testdrive.demo") is True
-    assert cratedb.database.count_records("testdrive.demo") >= 500
-
-
-def test_line_protocol_load_table_wrong_cratedb_url_failure(caplog, cratedb, needs_sqlalchemy2):
-    """
-    CLI test: Invoke `ctk load table` for InfluxDB line protocol (ILP) file.
-    """
-    ilp_url = "https://github.com/influxdata/influxdb2-sample-data/raw/master/noaa-ndbc-data/latest-observations.lp"
-    cratedb_url = f"{cratedb.get_connection_url()}/testdrive"
-
-    # Run transfer command.
-    runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb_url})
-    with pytest.raises(ValueError) as ex:
-        runner.invoke(
-            cli,
-            args=f"load table {ilp_url}",
-            catch_exceptions=False,
-        )
-    assert ex.match("Table name is missing. Please adjust CrateDB database URL.")
+    assert cratedb.database.table_exists("testdrive.ndbc") is True
+    assert cratedb.database.refresh_table("testdrive.ndbc") is True
+    assert cratedb.database.count_records("testdrive.ndbc") >= 500
 
 
 def test_influxdb2_load_table(caplog, cratedb, influxdb, needs_sqlalchemy2):


### PR DESCRIPTION
## About
This pulls in some updates to influxio. Thanks for the bug reports, @ZillKhan.

## Backlog
- [x] Documentation about the new `timeout` parameter on the InfluxDB source URL.
- [x] Remedy `ValueError: Table name is missing. Please adjust CrateDB database URL.` when loading multiple tables.

## References
- GH-509
- https://github.com/daq-tools/influxio/issues/182
- https://github.com/daq-tools/influxio/issues/183
- https://github.com/daq-tools/influxio/releases/tag/v0.6.0