### PR TITLE
CI: Fix Azurite integration testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,7 @@ optional-dependencies.settings = [
   "cratedb-toolkit[docs-api]",
 ]
 optional-dependencies.test = [
+  "azure-storage-blob<12.27",                          # Testcontainers: "ContainerClient" has no attribute "_format_url"
   "cratedb-toolkit[testing]",
   "httpx<0.29",
   "ipywidgets<9",


### PR DESCRIPTION
## Problem
CI started failing on Oct 16 [^1]. Maybe the reason is `azure-storage-blob 12.27.0`, released on Oct 15 [^2]?

[^1]: `"ContainerClient" has no attribute "_format_url"`
    https://github.com/crate/cratedb-toolkit/actions/runs/18549263203/job/52873487148#step:7:51

[^2]: https://pypi.org/project/azure-storage-blob/12.27.0/
