### PR TITLE
CI: Use Python 3.13 where applicable to speed up builds again

### DIFF
--- a/.github/workflows/cratedb-cloud.yml
+++ b/.github/workflows/cratedb-cloud.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: [
-          "3.14",
+          "3.13",
         ]
 
     env:

--- a/.github/workflows/influxdb.yml
+++ b/.github/workflows/influxdb.yml
@@ -39,7 +39,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: [
           "3.9",
-          "3.14",
+          "3.13",
         ]
         influxdb-version: ["2.6", "2.7"]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: [
           "3.9",
-          "3.14",
+          "3.13",
         ]
 
     env:


### PR DESCRIPTION
## About

We've [observed](https://github.com/crate/cratedb-toolkit/pull/563#issuecomment-3463651454) a few slowdowns after updating to Python 3.14 on CI prematurely. This patch dials back to improve (decrease) build time again.
