### PR TITLE
CI: Validate InfluxDB I/O adapter on Python 3.14

### DIFF
--- a/.github/workflows/influxdb.yml
+++ b/.github/workflows/influxdb.yml
@@ -39,7 +39,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: [
           "3.9",
-          "3.13",
+          "3.14",
         ]
         influxdb-version: ["2.6", "2.7"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,18 +166,20 @@ optional-dependencies.full = [
   "cratedb-toolkit[cfr,datasets,docs-api,io,mcp,service]",
 ]
 optional-dependencies.influxdb = [
-  "cratedb-toolkit[io]",
+  "cratedb-toolkit[io-base]",
   "influxio>=0.6,<1",
+  "sqlalchemy>=2",
 ]
 optional-dependencies.io = [
   "cratedb-toolkit[io-base]",
+  "pandas>=1,<2.3",
   "sqlalchemy>=2",
 ]
 optional-dependencies.io-base = [
   "cr8",
   "dask[dataframe]>=2020",
   "fsspec[http,s3]",
-  "pandas>=1,<2.3",
+  "pandas>=1,<2.4",
   "polars<1.34",
   "universal-pathlib<0.4",
 ]


### PR DESCRIPTION
## About
Python 3.14 wheels for `line-protocol-parser` have just been published. Thanks a stack, @Penlect.

## References
- https://github.com/Penlect/line-protocol-parser/issues/14
- https://github.com/Penlect/line-protocol-parser/issues/16