### PR TITLE
Tests: Fix minio dependency woes about ctor signature changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,7 @@ optional-dependencies.test = [
   "httpx<0.29",
   "ipywidgets<9",
   "markdown-it-py<4",
+  "minio<7.2.19",  # Temporary, until newer `testcontainers` release.
   "pueblo[dataframe,notebook,testing]>=0.0.11",
   "pydantic-core<3",
   "responses<0.26",


### PR DESCRIPTION
## Problem
With [minio 7.2.19](https://pypi.org/project/minio/#history), released on Nov 24, 2025, the workflow breaks.
```python
TypeError: Minio.__init__() takes 1 positional argument but 2 positional arguments (and 3 keyword-only arguments) were given
```

## References
- https://github.com/minio/minio-py/issues/1537
- https://github.com/testcontainers/testcontainers-python/issues/932
- https://github.com/crate/crate/pull/18770
