### PR TITLE
CI: Use more Python 3.14 (next)

### DIFF
--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -49,7 +49,7 @@ jobs:
         ]
         python-version: [
           "3.10",
-          "3.13",
+          "3.14",
         ]
 
     env:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         activate-environment: 'true'
         enable-cache: true
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Set up project
       run: |


### PR DESCRIPTION
Just maintenance. A few requirements are not ready for Python 3.14, yet.