### PR TITLE
TEMP: Don't use aiobotocore 3.1.1, released on Jan 20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,7 @@ optional-dependencies.io-recipe = [
   "tikray>=0.2,<0.4",
 ]
 optional-dependencies.kinesis = [
-  "aiobotocore<3.1",
+  "aiobotocore<3.1,!=3.1.1",
   "async-kinesis>=2,<3",
   "botocore<1.41",
   "commons-codec>=0.0.24",


### PR DESCRIPTION
Investigations.