### PR TITLE
Tests/Kinesis: Re-enable test matrix slot for Python 3.11

### DIFF
--- a/.github/workflows/kinesis.yml
+++ b/.github/workflows/kinesis.yml
@@ -39,7 +39,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: [
           "3.10",
-          # "3.11",  # Stopped working on 2026-01-22, see https://github.com/crate/cratedb-toolkit/issues/605.
+          "3.11",
           "3.12",
           "3.13",
         ]


### PR DESCRIPTION
## Problem
The workflow started failing on 2026-01-22 for unknown reasons yet, on Python 3.11 only. This patch aims to re-enable the corresponding test matrix slot, hopefully together with a solution. Until then, it acts as a demonstrator for the issue at hand.

## References
- GH-605