### PR TITLE
CI: Validate against InfluxDB 2.8

### DIFF
--- a/.github/workflows/influxdb.yml
+++ b/.github/workflows/influxdb.yml
@@ -41,7 +41,16 @@ jobs:
           "3.9",
           "3.14",
         ]
-        influxdb-version: ["2.6", "2.7"]
+        influxdb-version: [
+          "2.8",
+        ]
+        include:
+          - influxdb-version: "2.6"
+            python-version: "3.14"
+            os: "ubuntu-latest"
+          - influxdb-version: "2.7"
+            python-version: "3.14"
+            os: "ubuntu-latest"
 
     env:
       OS: ${{ matrix.os }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Dependencies: Permitted installation of pyarrow 22
 - Dependencies: Permitted installation of duckdb 1.x
 - PyMongo adapter: Adapted to CrateDB 6.2+ which disallows writes to `_id` columns
+- CI: Validated against InfluxDB 2.8
 
 ## 2025/08/19 v0.0.41
 - I/O: Updated to `influxio-0.6.0`. Thanks, @ZillKhan.


### PR DESCRIPTION
[InfluxDB 2.8.0](https://github.com/influxdata/influxdb/releases/tag/v2.8.0) was released on Dec 12, 2025.