### PR TITLE
OCI: Use Python 3.13 for image `cratedb-toolkit-ingest`

### DIFF
--- a/release/oci-ingest/Dockerfile
+++ b/release/oci-ingest/Dockerfile
@@ -5,7 +5,7 @@
 # - https://github.com/FernandoMiguel/Buildkit#mounttypecache
 
 # Stage 1: Build wheel package
-FROM python:3.12-slim-bookworm AS build
+FROM python:3.13-slim-bookworm AS build
 
 # Enable concurrent multi-arch builds.
 # https://github.com/docker/buildx/issues/549#issuecomment-1788297892
@@ -35,7 +35,7 @@ RUN pip install build
 RUN python -m build --wheel ${BUILD}
 
 
-FROM python:3.12-slim-bookworm AS package
+FROM python:3.13-slim-bookworm AS package
 
 LABEL org.opencontainers.image.source="https://github.com/crate/cratedb-toolkit" \
       org.opencontainers.image.title="cratedb-toolkit (ingest)" \


### PR DESCRIPTION
Just maintenance.