### PR TITLE
CI: Save resources by turning off packaging on PRs

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,13 +1,18 @@
 # Stage PyInstaller application bundles through GitHub Actions (GHA) to GitHub Workflow Artifacts.
 # https://github.com/actions/upload-artifact#where-does-the-upload-go
-
 name: "Release: Application Bundle"
 
 on:
-  pull_request: ~
   push:
     tags:
       - '*'
+
+  # Run on pull requests.
+  # pull_request:
+
+  # Run each night.
+  schedule:
+    - cron: '55 04 * * *'  # every day at 04:55 am
 
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:

--- a/.github/workflows/release-oci-full.yml
+++ b/.github/workflows/release-oci-full.yml
@@ -2,11 +2,14 @@
 name: "Release: OCI to GHCR (full)"
 
 on:
-  pull_request: ~
   push:
     tags:
       - '*.*.*'
 
+  # Run on pull requests.
+  # pull_request:
+
+  # Run each night.
   schedule:
     - cron: '45 04 * * *'  # every day at 04:45 am
 

--- a/.github/workflows/release-oci-ingest.yml
+++ b/.github/workflows/release-oci-ingest.yml
@@ -2,11 +2,14 @@
 name: "Release: OCI to GHCR (ingest)"
 
 on:
-  pull_request: ~
   push:
     tags:
       - '*.*.*'
 
+  # Run on pull requests.
+  # pull_request:
+
+  # Run each night.
   schedule:
     - cron: '50 04 * * *'  # every day at 04:50 am
 


### PR DESCRIPTION
## About
Only run packaging each night, not on PR.
This can be toggled back any time when needed.
