### PR TITLE
Renovate: Configure `rangeStrategy=widen`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "rangeStrategy": "widen",
 }


### PR DESCRIPTION
After switching from Dependabot to Renovate, the behavior is not yet like we want it to be. Currently, updates seem to _narrow_ the version range.

- GH-657

Let's see how configuring it differently works better.

https://docs.renovatebot.com/configuration-options/#rangestrategy
