### PR TITLE
feat(kinesis): add ctk kinesis CLI with checkpoint listing and pruning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Kinesis: Added `ctk kinesis` CLI group with `list-checkpoints` and
+  `prune-checkpoints` commands for checkpoint table maintenance
 - Dependencies: Permitted installation of click 8.3
 
 ## 2026/03/16 v0.0.46

--- a/cratedb_toolkit/cli.py
+++ b/cratedb_toolkit/cli.py
@@ -12,6 +12,7 @@ from .docs.cli import cli as docs_cli
 from .info.cli import cli as info_cli
 from .io.cli import cli_load as io_cli_load
 from .io.cli import cli_save as io_cli_save
+from .io.kinesis.cli import cli as kinesis_cli
 from .query.cli import cli as query_cli
 from .settings.cli import cli as settings_cli
 from .shell.cli import cli as shell_cli
@@ -33,6 +34,7 @@ cli.add_command(cfr_cli, name="cfr")
 cli.add_command(cloud_cli, name="cluster")
 cli.add_command(docs_cli, name="docs")
 cli.add_command(dms_cli, name="dms")
+cli.add_command(kinesis_cli, name="kinesis")
 cli.add_command(io_cli_load, name="load")
 cli.add_command(io_cli_save, name="save")
 cli.add_command(query_cli, name="query")

--- a/cratedb_toolkit/exception.py
+++ b/cratedb_toolkit/exception.py
@@ -7,6 +7,10 @@ class TableNotFound(Exception):
     pass
 
 
+class CheckpointTableNotFound(Exception):
+    pass
+
+
 class OperationFailed(Exception):
     pass
 

--- a/cratedb_toolkit/io/kinesis/cli.py
+++ b/cratedb_toolkit/io/kinesis/cli.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2021-2025, Crate.io Inc.
+# Distributed under the terms of the AGPLv3 license, see LICENSE.
+"""
+CLI commands for Kinesis checkpoint maintenance.
+
+Registered as ``ctk kinesis`` subcommand group. Does not depend on
+the ``kinesis`` (async-kinesis) package, only on SQLAlchemy.
+"""
+
+import logging
+import sys
+import typing as t
+
+import click
+from click_aliases import ClickAliasedGroup
+
+from cratedb_toolkit.exception import CheckpointTableNotFound
+from cratedb_toolkit.io.kinesis.maintenance import list_checkpoints, prune_checkpoints
+from cratedb_toolkit.model import DatabaseAddress
+from cratedb_toolkit.util.cli import make_command
+from cratedb_toolkit.util.data import jd
+
+logger = logging.getLogger(__name__)
+
+schema_option: t.Any = click.option(
+    "--schema",
+    type=str,
+    required=False,
+    envvar="CRATEDB_EXT_SCHEMA",
+    help="Schema where the checkpoint table lives (default: ext)",
+)
+
+namespace_option: t.Any = click.option(
+    "--namespace",
+    type=str,
+    required=False,
+    help="Filter by checkpoint namespace (stream name)",
+)
+
+dryrun_option: t.Any = click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show what would be deleted without actually deleting",
+)
+
+
+@click.group(cls=ClickAliasedGroup)
+def cli():
+    """Kinesis checkpoint management."""
+
+
+@make_command(cli, "list-checkpoints", aliases=["ls"])
+@click.argument("dburi", envvar="CRATEDB_URI")
+@schema_option
+@namespace_option
+def list_checkpoints_cmd(dburi: str, schema: t.Optional[str], namespace: t.Optional[str]):
+    """List checkpoint records."""
+    import sqlalchemy as sa
+
+    schema = schema or "ext"
+    engine = sa.create_engine(str(DatabaseAddress.from_string(dburi).decode()[0]))
+    try:
+        rows = list_checkpoints(engine=engine, schema=schema, namespace=namespace)
+    except CheckpointTableNotFound as ex:
+        click.echo(str(ex), err=True)
+        sys.exit(1)
+    finally:
+        engine.dispose()
+
+    if not rows:
+        click.echo("No checkpoints found.")
+        return
+
+    jd(rows)
+
+
+@make_command(cli, "prune-checkpoints", aliases=["prune"])
+@click.argument("dburi", envvar="CRATEDB_URI")
+@click.option("--older-than", type=str, required=False, help="Age threshold, e.g. 30d, 24h, 2w")
+@schema_option
+@namespace_option
+@click.option("--include-active", is_flag=True, default=False, help="Also delete active rows (use with care)")
+@dryrun_option
+@click.option("--yes", is_flag=True, default=False, help="Skip confirmation prompt")
+def prune_checkpoints_cmd(
+    dburi: str,
+    older_than: t.Optional[str],
+    schema: t.Optional[str],
+    namespace: t.Optional[str],
+    include_active: bool,
+    dry_run: bool,
+    yes: bool,
+):
+    """
+    Delete checkpoint rows matching filters.
+
+    At least one of --older-than or --namespace is required.
+    By default only inactive rows (active=FALSE) are eligible.
+    """
+    import sqlalchemy as sa
+
+    if not older_than and not namespace:
+        raise click.UsageError("At least one of --older-than or --namespace is required")
+
+    schema = schema or "ext"
+    engine = sa.create_engine(str(DatabaseAddress.from_string(dburi).decode()[0]))
+    try:
+        if dry_run:
+            result = prune_checkpoints(
+                engine=engine,
+                schema=schema,
+                older_than=older_than,
+                namespace=namespace,
+                include_active=include_active,
+                dry_run=True,
+            )
+            jd(result)
+            return
+
+        if not yes:
+            preview = prune_checkpoints(
+                engine=engine,
+                schema=schema,
+                older_than=older_than,
+                namespace=namespace,
+                include_active=include_active,
+                dry_run=True,
+            )
+            count = preview["would_delete"]
+            if count == 0:
+                click.echo("No matching rows to prune.")
+                return
+            click.confirm(f"Delete {count} checkpoint row(s)?", abort=True)
+
+        result = prune_checkpoints(
+            engine=engine,
+            schema=schema,
+            older_than=older_than,
+            namespace=namespace,
+            include_active=include_active,
+        )
+        jd(result)
+    except CheckpointTableNotFound as ex:
+        click.echo(str(ex), err=True)
+        sys.exit(1)
+    except ValueError as ex:
+        click.echo(f"Error: {ex}", err=True)
+        sys.exit(1)
+    finally:
+        engine.dispose()

--- a/cratedb_toolkit/io/kinesis/cli.py
+++ b/cratedb_toolkit/io/kinesis/cli.py
@@ -60,7 +60,7 @@ def list_checkpoints_cmd(dburi: str, schema: t.Optional[str], namespace: t.Optio
     import sqlalchemy as sa
 
     schema = schema or "ext"
-    engine = sa.create_engine(str(DatabaseAddress.from_string(dburi).decode()[0]))
+    engine = sa.create_engine(DatabaseAddress.from_string(dburi).sqlalchemy_url)
     # Synchronize CrateDB write operations to avoid eventual consistency,
     # i.e. make rows visible to subsequent queries immediately.
     # https://cratedb.com/docs/sqlalchemy-cratedb/support.html#synthetic-table-refresh-after-dml
@@ -110,7 +110,7 @@ def prune_checkpoints_cmd(
         raise click.UsageError("At least one of --older-than or --namespace is required")
 
     schema = schema or "ext"
-    engine = sa.create_engine(str(DatabaseAddress.from_string(dburi).decode()[0]))
+    engine = sa.create_engine(DatabaseAddress.from_string(dburi).sqlalchemy_url)
     # Synchronize CrateDB write operations to avoid eventual consistency,
     # i.e. make rows visible to subsequent queries immediately.
     # https://cratedb.com/docs/sqlalchemy-cratedb/support.html#synthetic-table-refresh-after-dml

--- a/cratedb_toolkit/io/kinesis/cli.py
+++ b/cratedb_toolkit/io/kinesis/cli.py
@@ -13,6 +13,7 @@ import typing as t
 
 import click
 from click_aliases import ClickAliasedGroup
+from sqlalchemy_cratedb.support import refresh_after_dml
 
 from cratedb_toolkit.exception import CheckpointTableNotFound
 from cratedb_toolkit.io.kinesis.maintenance import list_checkpoints, prune_checkpoints
@@ -60,6 +61,11 @@ def list_checkpoints_cmd(dburi: str, schema: t.Optional[str], namespace: t.Optio
 
     schema = schema or "ext"
     engine = sa.create_engine(str(DatabaseAddress.from_string(dburi).decode()[0]))
+    # Synchronize CrateDB write operations to avoid eventual consistency,
+    # i.e. make rows visible to subsequent queries immediately.
+    # https://cratedb.com/docs/sqlalchemy-cratedb/support.html#synthetic-table-refresh-after-dml
+    refresh_after_dml(engine)
+
     try:
         rows = list_checkpoints(engine=engine, schema=schema, namespace=namespace)
     except CheckpointTableNotFound as ex:
@@ -105,6 +111,11 @@ def prune_checkpoints_cmd(
 
     schema = schema or "ext"
     engine = sa.create_engine(str(DatabaseAddress.from_string(dburi).decode()[0]))
+    # Synchronize CrateDB write operations to avoid eventual consistency,
+    # i.e. make rows visible to subsequent queries immediately.
+    # https://cratedb.com/docs/sqlalchemy-cratedb/support.html#synthetic-table-refresh-after-dml
+    refresh_after_dml(engine)
+
     try:
         if dry_run:
             result = prune_checkpoints(

--- a/cratedb_toolkit/io/kinesis/maintenance.py
+++ b/cratedb_toolkit/io/kinesis/maintenance.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2021-2025, Crate.io Inc.
+# Distributed under the terms of the AGPLv3 license, see LICENSE.
+"""
+Standalone maintenance operations for the Kinesis checkpoint table.
+
+Decoupled from ``CrateDBCheckPointer`` so it can be imported without
+the ``kinesis`` (async-kinesis) dependency.
+"""
+
+import logging
+import re
+import typing as t
+from datetime import datetime, timedelta, timezone
+
+import sqlalchemy as sa
+
+from cratedb_toolkit.exception import CheckpointTableNotFound
+
+logger = logging.getLogger(__name__)
+
+# SQL identifier pattern: prevents injection via dynamic DDL/DML.
+# Hyphens are allowed because all identifiers are double-quoted in generated SQL.
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+
+# Duration pattern: e.g. "7d", "24h", "30m", "90s", "2w", or combinations like "1d12h".
+_DURATION_RE = re.compile(r"^(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
+
+TABLE_NAME = "kinesis_checkpoints"
+
+
+def _validate_identifier(value: str) -> None:
+    """Validate a SQL identifier to prevent injection."""
+    if not value or not _IDENTIFIER_RE.match(value):
+        raise ValueError(f"Invalid SQL identifier: {value!r}")
+
+
+def _qualified_table(schema: str) -> str:
+    """Return a fully-qualified, double-quoted table reference."""
+    _validate_identifier(schema)
+    return f'"{schema}"."{TABLE_NAME}"'
+
+
+def _check_table_exists(conn: sa.Connection, schema: str) -> None:
+    """Raise ``CheckpointTableNotFound`` if the checkpoint table does not exist."""
+    result = conn.execute(
+        sa.text("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = :schema AND table_name = :table"),
+        {"schema": schema, "table": TABLE_NAME},
+    ).scalar()
+    if not result:
+        raise CheckpointTableNotFound(f"Checkpoint table {_qualified_table(schema)} does not exist")
+
+
+def parse_duration(value: str) -> timedelta:
+    """
+    Parse a human-friendly duration string into a ``timedelta``.
+
+    Accepted formats: ``2w``, ``7d``, ``24h``, ``30m``, ``90s``, or
+    combinations like ``1d12h``. At least one component is required
+    and the total duration must be positive.
+
+    Raises ``ValueError`` for invalid or zero-length durations.
+    """
+    value = value.strip()
+    if not value:
+        raise ValueError(
+            "Invalid duration: ''. Use a combination of Nw, Nd, Nh, Nm, Ns (e.g. '7d', '24h', '2w', '1d12h')."
+        )
+    match = _DURATION_RE.match(value)
+    if not match:
+        raise ValueError(
+            f"Invalid duration: {value!r}. Use a combination of Nw, Nd, Nh, Nm, Ns (e.g. '7d', '24h', '2w', '1d12h')."
+        )
+
+    weeks = int(match.group(1) or 0)
+    days = int(match.group(2) or 0)
+    hours = int(match.group(3) or 0)
+    minutes = int(match.group(4) or 0)
+    seconds = int(match.group(5) or 0)
+
+    td = timedelta(weeks=weeks, days=days, hours=hours, minutes=minutes, seconds=seconds)
+    if td.total_seconds() <= 0:
+        raise ValueError(f"Duration must be positive, got: {value!r}")
+    return td
+
+
+def list_checkpoints(
+    engine: sa.Engine,
+    schema: str = "ext",
+    namespace: t.Optional[str] = None,
+) -> t.List[t.Dict[str, t.Any]]:
+    """
+    List checkpoint records, optionally filtered by namespace.
+
+    Returns a list of dicts with keys: ``namespace``, ``shard_id``,
+    ``sequence``, ``active``, ``updated_at``.
+    """
+    table = _qualified_table(schema)
+    with engine.connect() as conn:
+        _check_table_exists(conn, schema)
+        conn.execute(sa.text(f"REFRESH TABLE {table}"))
+
+        where = ' WHERE "namespace" = :ns' if namespace else ""
+        params = {"ns": namespace} if namespace else {}
+        sql = sa.text(
+            f'SELECT "namespace", "shard_id", "sequence", "active", "updated_at" '  # noqa: S608
+            f"FROM {table}{where} "
+            f'ORDER BY "namespace", "shard_id"'
+        )
+        rows = conn.execute(sql, params).fetchall()
+
+    return [dict(row._mapping) for row in rows]
+
+
+def prune_checkpoints(
+    engine: sa.Engine,
+    schema: str = "ext",
+    older_than: t.Optional[str] = None,
+    namespace: t.Optional[str] = None,
+    include_active: bool = False,
+    dry_run: bool = False,
+) -> t.Dict[str, t.Any]:
+    """
+    Delete checkpoint rows matching the given filters.
+
+    By default only rows with ``active = FALSE`` are eligible. Pass
+    ``include_active=True`` to also delete active rows (use with care,
+    stop consumers first).
+
+    At least one of ``older_than`` or ``namespace`` is required.
+
+    Returns a dict with ``deleted`` count (or ``would_delete`` in dry-run
+    mode) and the ``cutoff`` timestamp used (if applicable).
+    """
+    if not older_than and not namespace:
+        raise ValueError("At least one of older_than or namespace is required")
+
+    table = _qualified_table(schema)
+    conditions: t.List[str] = []
+    params: t.Dict[str, t.Any] = {}
+    result_meta: t.Dict[str, t.Any] = {}
+
+    if not include_active:
+        conditions.append('"active" = FALSE')
+
+    if older_than:
+        age = parse_duration(older_than)
+        cutoff = datetime.now(tz=timezone.utc) - age
+        conditions.append('"updated_at" < :cutoff')
+        params["cutoff"] = cutoff
+        result_meta["cutoff"] = cutoff.isoformat()
+
+    if namespace:
+        conditions.append('"namespace" = :ns')
+        params["ns"] = namespace
+
+    where = " AND ".join(conditions)
+
+    with engine.connect() as conn:
+        _check_table_exists(conn, schema)
+        conn.execute(sa.text(f"REFRESH TABLE {table}"))
+
+        if dry_run:
+            count_sql = sa.text(f"SELECT COUNT(*) FROM {table} WHERE {where}")  # noqa: S608
+            count = conn.execute(count_sql, params).scalar()
+            return {"would_delete": count, **result_meta}
+
+        delete_sql = sa.text(f"DELETE FROM {table} WHERE {where}")  # noqa: S608
+        result = conn.execute(delete_sql, params)
+        conn.commit()
+        return {"deleted": result.rowcount, **result_meta}

--- a/cratedb_toolkit/io/kinesis/maintenance.py
+++ b/cratedb_toolkit/io/kinesis/maintenance.py
@@ -10,20 +10,18 @@ the ``kinesis`` (async-kinesis) dependency.
 import logging
 import re
 import typing as t
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import sqlalchemy as sa
 
 from cratedb_toolkit.exception import CheckpointTableNotFound
+from cratedb_toolkit.util.date import parse_duration
 
 logger = logging.getLogger(__name__)
 
 # SQL identifier pattern: prevents injection via dynamic DDL/DML.
 # Hyphens are allowed because all identifiers are double-quoted in generated SQL.
 _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
-
-# Duration pattern: e.g. "7d", "24h", "30m", "90s", "2w", or combinations like "1d12h".
-_DURATION_RE = re.compile(r"^(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
 
 TABLE_NAME = "kinesis_checkpoints"
 
@@ -50,39 +48,6 @@ def _check_table_exists(conn: sa.Connection, schema: str) -> None:
         raise CheckpointTableNotFound(f"Checkpoint table {_qualified_table(schema)} does not exist")
 
 
-def parse_duration(value: str) -> timedelta:
-    """
-    Parse a human-friendly duration string into a ``timedelta``.
-
-    Accepted formats: ``2w``, ``7d``, ``24h``, ``30m``, ``90s``, or
-    combinations like ``1d12h``. At least one component is required
-    and the total duration must be positive.
-
-    Raises ``ValueError`` for invalid or zero-length durations.
-    """
-    value = value.strip()
-    if not value:
-        raise ValueError(
-            "Invalid duration: ''. Use a combination of Nw, Nd, Nh, Nm, Ns (e.g. '7d', '24h', '2w', '1d12h')."
-        )
-    match = _DURATION_RE.match(value)
-    if not match:
-        raise ValueError(
-            f"Invalid duration: {value!r}. Use a combination of Nw, Nd, Nh, Nm, Ns (e.g. '7d', '24h', '2w', '1d12h')."
-        )
-
-    weeks = int(match.group(1) or 0)
-    days = int(match.group(2) or 0)
-    hours = int(match.group(3) or 0)
-    minutes = int(match.group(4) or 0)
-    seconds = int(match.group(5) or 0)
-
-    td = timedelta(weeks=weeks, days=days, hours=hours, minutes=minutes, seconds=seconds)
-    if td.total_seconds() <= 0:
-        raise ValueError(f"Duration must be positive, got: {value!r}")
-    return td
-
-
 def list_checkpoints(
     engine: sa.Engine,
     schema: str = "ext",
@@ -97,6 +62,8 @@ def list_checkpoints(
     table = _qualified_table(schema)
     with engine.connect() as conn:
         _check_table_exists(conn, schema)
+        # Explicit refresh ensures visibility of rows written by other
+        # processes (e.g. CrateDBCheckPointer / Kinesis consumers).
         conn.execute(sa.text(f"REFRESH TABLE {table}"))
 
         where = ' WHERE "namespace" = :ns' if namespace else ""
@@ -157,6 +124,8 @@ def prune_checkpoints(
 
     with engine.connect() as conn:
         _check_table_exists(conn, schema)
+        # Explicit refresh ensures visibility of rows written by other
+        # processes (e.g. CrateDBCheckPointer / Kinesis consumers).
         conn.execute(sa.text(f"REFRESH TABLE {table}"))
 
         if dry_run:

--- a/cratedb_toolkit/model.py
+++ b/cratedb_toolkit/model.py
@@ -176,6 +176,13 @@ class DatabaseAddress:
         return uri, TableAddress(database, table)
 
     @property
+    def sqlalchemy_url(self) -> str:
+        """
+        Return a clean SQLAlchemy connection URL (path/table stripped).
+        """
+        return str(self.decode()[0])
+
+    @property
     def username(self) -> t.Union[str, None]:
         """
         Return the username of the database URI.

--- a/cratedb_toolkit/util/date.py
+++ b/cratedb_toolkit/util/date.py
@@ -1,5 +1,9 @@
 import datetime as dt
 import math
+import re
+
+# Duration pattern: e.g. "7d", "24h", "30m", "90s", "2w", or combinations like "1d12h".
+_DURATION_RE = re.compile(r"^(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
 
 
 def truncate_milliseconds(timestamp: dt.datetime):
@@ -11,3 +15,36 @@ def truncate_milliseconds(timestamp: dt.datetime):
     """
     dec, integer = math.modf(timestamp.microsecond / 1000)
     return timestamp - dt.timedelta(microseconds=round(dec * 1000))
+
+
+def parse_duration(value: str) -> dt.timedelta:
+    """
+    Parse a human-friendly duration string into a ``timedelta``.
+
+    Accepted formats: ``2w``, ``7d``, ``24h``, ``30m``, ``90s``, or
+    combinations like ``1d12h``. At least one component is required
+    and the total duration must be positive.
+
+    Raises ``ValueError`` for invalid or zero-length durations.
+    """
+    value = value.strip()
+    if not value:
+        raise ValueError(
+            "Invalid duration: ''. Use a combination of Nw, Nd, Nh, Nm, Ns (e.g. '7d', '24h', '2w', '1d12h')."
+        )
+    match = _DURATION_RE.match(value)
+    if not match:
+        raise ValueError(
+            f"Invalid duration: {value!r}. Use a combination of Nw, Nd, Nh, Nm, Ns (e.g. '7d', '24h', '2w', '1d12h')."
+        )
+
+    weeks = int(match.group(1) or 0)
+    days = int(match.group(2) or 0)
+    hours = int(match.group(3) or 0)
+    minutes = int(match.group(4) or 0)
+    seconds = int(match.group(5) or 0)
+
+    td = dt.timedelta(weeks=weeks, days=days, hours=hours, minutes=minutes, seconds=seconds)
+    if td.total_seconds() <= 0:
+        raise ValueError(f"Duration must be positive, got: {value!r}")
+    return td

--- a/doc/io/stream/kinesis.md
+++ b/doc/io/stream/kinesis.md
@@ -192,7 +192,53 @@ workloads (a handful of streams with 1-10 shards each), the table stays
 small indefinitely.
 
 Rows may accumulate over time from decommissioned pipelines or Kinesis shard
-splits. Inspect the checkpoint state with:
+splits. Use the `ctk kinesis` commands to inspect and clean up checkpoint state.
+
+**List checkpoints:**
+
+```shell
+# All checkpoints
+ctk kinesis list-checkpoints "crate://localhost/"
+
+# Filter by namespace (stream name)
+ctk kinesis list-checkpoints --namespace my-stream "crate://localhost/"
+```
+
+**Prune stale checkpoints:**
+
+At least one of `--older-than` or `--namespace` is required. By default only
+inactive rows (`active=FALSE`) are eligible for deletion.
+
+```shell
+# Preview what would be deleted (dry run)
+ctk kinesis prune-checkpoints --older-than 30d --dry-run "crate://localhost/"
+
+# Delete inactive checkpoints older than 30 days
+ctk kinesis prune-checkpoints --older-than 30d "crate://localhost/"
+
+# Remove all checkpoints for a decommissioned pipeline
+ctk kinesis prune-checkpoints --namespace old-pipeline "crate://localhost/"
+
+# Skip confirmation prompt
+ctk kinesis prune-checkpoints --older-than 30d --yes "crate://localhost/"
+
+# Custom schema (if not using default "ext")
+ctk kinesis prune-checkpoints --older-than 7d --schema my_ext "crate://localhost/"
+```
+
+The `--older-than` option accepts durations like `7d`, `24h`, `2w`, or
+combinations like `1d12h`.
+
+:::{note}
+A healthy but idle consumer's checkpoints can look stale by `updated_at`.
+Stop consumers before pruning, or use `--dry-run` to verify what will be
+deleted.
+:::
+
+:::{rubric} Manual SQL
+:::
+
+You can also query and manage the checkpoint table directly:
 
 ```sql
 SELECT "namespace", "shard_id", "sequence", "active", "updated_at"
@@ -200,19 +246,10 @@ FROM "ext"."kinesis_checkpoints"
 ORDER BY "updated_at" DESC;
 ```
 
-Prune stale checkpoints (inactive shards older than 30 days):
-
 ```sql
 DELETE FROM "ext"."kinesis_checkpoints"
 WHERE "active" = FALSE
 AND "updated_at" < NOW() - INTERVAL '30 days';
-```
-
-To remove all checkpoints for a decommissioned pipeline:
-
-```sql
-DELETE FROM "ext"."kinesis_checkpoints"
-WHERE "namespace" = 'old-pipeline-name';
 ```
 
 ## See also

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,7 +138,6 @@ def cratedb(cratedb_custom_service):
     """
     cratedb_custom_service.reset(schemas=RESET_SCHEMAS, tables=RESET_TABLES)
     yield cratedb_custom_service
-    cratedb_custom_service.database.close()
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import typing as t
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy_cratedb.support import refresh_after_dml
 from verlib2 import Version
 
 import cratedb_toolkit
@@ -135,6 +136,22 @@ def cratedb(cratedb_custom_service):
     """
     Provide a fresh canvas to each test case invocation, by resetting database content.
     """
+    cratedb_custom_service.reset(schemas=RESET_SCHEMAS, tables=RESET_TABLES)
+    yield cratedb_custom_service
+    cratedb_custom_service.database.close()
+
+
+@pytest.fixture(scope="function")
+def cratedb_synchronized(cratedb_custom_service):
+    """
+    Provide a fresh canvas to each test case invocation, by resetting database content.
+
+    Also, configure the SQLAlchemy engine to synchronize CrateDB write operations to
+    avoid eventual consistency, i.e. make rows visible to subsequent queries immediately.
+
+    https://cratedb.com/docs/sqlalchemy-cratedb/support.html#synthetic-table-refresh-after-dml
+    """
+    refresh_after_dml(cratedb_custom_service.database.engine)
     cratedb_custom_service.reset(schemas=RESET_SCHEMAS, tables=RESET_TABLES)
     yield cratedb_custom_service
 

--- a/tests/io/test_kinesis_maintenance.py
+++ b/tests/io/test_kinesis_maintenance.py
@@ -18,7 +18,6 @@ from cratedb_toolkit.exception import CheckpointTableNotFound
 from cratedb_toolkit.io.kinesis.maintenance import (
     TABLE_NAME,
     list_checkpoints,
-    parse_duration,
     prune_checkpoints,
 )
 from tests.conftest import TESTDRIVE_EXT_SCHEMA
@@ -65,56 +64,6 @@ def _insert_checkpoint(
         conn.commit()
 
 
-
-
-# -- parse_duration tests (pure, no DB) --
-
-
-def test_parse_duration_days():
-    assert parse_duration("7d") == timedelta(days=7)
-
-
-def test_parse_duration_hours():
-    assert parse_duration("24h") == timedelta(hours=24)
-
-
-def test_parse_duration_minutes():
-    assert parse_duration("30m") == timedelta(minutes=30)
-
-
-def test_parse_duration_seconds():
-    assert parse_duration("90s") == timedelta(seconds=90)
-
-
-def test_parse_duration_weeks():
-    assert parse_duration("2w") == timedelta(weeks=2)
-
-
-def test_parse_duration_combined():
-    assert parse_duration("1d12h") == timedelta(days=1, hours=12)
-
-
-def test_parse_duration_full_combination():
-    assert parse_duration("1w2d3h15m30s") == timedelta(weeks=1, days=2, hours=3, minutes=15, seconds=30)
-
-
-def test_parse_duration_whitespace_stripped():
-    assert parse_duration("  7d  ") == timedelta(days=7)
-
-
-def test_parse_duration_invalid_format():
-    with pytest.raises(ValueError, match="Invalid duration"):
-        parse_duration("seven days")
-
-
-def test_parse_duration_empty_string():
-    with pytest.raises(ValueError, match="Invalid duration"):
-        parse_duration("")
-
-
-def test_parse_duration_zero():
-    with pytest.raises(ValueError, match="must be positive"):
-        parse_duration("0d")
 
 
 # -- list_checkpoints tests --

--- a/tests/io/test_kinesis_maintenance.py
+++ b/tests/io/test_kinesis_maintenance.py
@@ -65,11 +65,6 @@ def _insert_checkpoint(
         conn.commit()
 
 
-def _refresh_table(engine: sa.Engine, schema: str) -> None:
-    """Flush CrateDB write buffer so rows are visible to subsequent queries."""
-    table = f'"{schema}"."{TABLE_NAME}"'
-    with engine.connect() as conn:
-        conn.execute(sa.text(f"REFRESH TABLE {table}"))
 
 
 # -- parse_duration tests (pure, no DB) --
@@ -125,225 +120,169 @@ def test_parse_duration_zero():
 # -- list_checkpoints tests --
 
 
-def test_list_checkpoints_table_not_found(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        with pytest.raises(CheckpointTableNotFound, match="does not exist"):
-            list_checkpoints(engine=engine, schema="nonexistent_schema")
-    finally:
-        engine.dispose()
+def test_list_checkpoints_table_not_found(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    with pytest.raises(CheckpointTableNotFound, match="does not exist"):
+        list_checkpoints(engine=engine, schema="nonexistent_schema")
 
 
-def test_list_checkpoints_empty_table(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
-        rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
-        assert rows == []
-    finally:
-        engine.dispose()
+def test_list_checkpoints_empty_table(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+    rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+    assert rows == []
 
 
-def test_list_checkpoints_all(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_a", "shard-0", "100", True)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_b", "shard-0", "200", False)
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+def test_list_checkpoints_all(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_a", "shard-0", "100", True)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_b", "shard-0", "200", False)
 
-        rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
-        assert len(rows) == 2
-        namespaces = {r["namespace"] for r in rows}
-        assert namespaces == {"stream_a", "stream_b"}
-    finally:
-        engine.dispose()
+    rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+    assert len(rows) == 2
+    namespaces = {r["namespace"] for r in rows}
+    assert namespaces == {"stream_a", "stream_b"}
 
 
-def test_list_checkpoints_filter_by_namespace(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_a", "shard-0", "100", True)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_b", "shard-0", "200", False)
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+def test_list_checkpoints_filter_by_namespace(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_a", "shard-0", "100", True)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_b", "shard-0", "200", False)
 
-        rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA, namespace="stream_a")
-        assert len(rows) == 1
-        assert rows[0]["namespace"] == "stream_a"
-    finally:
-        engine.dispose()
+    rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA, namespace="stream_a")
+    assert len(rows) == 1
+    assert rows[0]["namespace"] == "stream_a"
 
 
-def test_list_checkpoints_result_keys(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "ns", "shard-0", "100", True)
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+def test_list_checkpoints_result_keys(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "ns", "shard-0", "100", True)
 
-        rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
-        assert len(rows) == 1
-        assert set(rows[0].keys()) == {"namespace", "shard_id", "sequence", "active", "updated_at"}
-    finally:
-        engine.dispose()
+    rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+    assert len(rows) == 1
+    assert set(rows[0].keys()) == {"namespace", "shard_id", "sequence", "active", "updated_at"}
 
 
 # -- prune_checkpoints tests --
 
 
-def test_prune_checkpoints_table_not_found(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        with pytest.raises(CheckpointTableNotFound, match="does not exist"):
-            prune_checkpoints(engine=engine, older_than="7d", schema="nonexistent_schema")
-    finally:
-        engine.dispose()
+def test_prune_checkpoints_table_not_found(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    with pytest.raises(CheckpointTableNotFound, match="does not exist"):
+        prune_checkpoints(engine=engine, older_than="7d", schema="nonexistent_schema")
 
 
-def test_prune_checkpoints_invalid_duration(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        with pytest.raises(ValueError, match="Invalid duration"):
-            prune_checkpoints(engine=engine, older_than="abc", schema=TESTDRIVE_EXT_SCHEMA)
-    finally:
-        engine.dispose()
+def test_prune_checkpoints_invalid_duration(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    with pytest.raises(ValueError, match="Invalid duration"):
+        prune_checkpoints(engine=engine, older_than="abc", schema=TESTDRIVE_EXT_SCHEMA)
 
 
-def test_prune_checkpoints_requires_filter(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        with pytest.raises(ValueError, match="At least one"):
-            prune_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
-    finally:
-        engine.dispose()
+def test_prune_checkpoints_requires_filter(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    with pytest.raises(ValueError, match="At least one"):
+        prune_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
 
 
-def test_prune_checkpoints_inactive_old_rows(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+def test_prune_checkpoints_inactive_old_rows(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
 
-        old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
-        recent_ts = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
+    recent_ts = datetime.now(tz=timezone.utc) - timedelta(hours=1)
 
-        # Old inactive (should be pruned).
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "old_stream", "shard-0", "50", False, old_ts)
-        # Old active (should NOT be pruned).
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "active_stream", "shard-0", "100", True, old_ts)
-        # Recent inactive (should NOT be pruned).
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "recent_stream", "shard-0", "200", False, recent_ts)
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+    # Old inactive (should be pruned).
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "old_stream", "shard-0", "50", False, old_ts)
+    # Old active (should NOT be pruned).
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "active_stream", "shard-0", "100", True, old_ts)
+    # Recent inactive (should NOT be pruned).
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "recent_stream", "shard-0", "200", False, recent_ts)
 
-        result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA)
-        assert result["deleted"] == 1
+    result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA)
+    assert result["deleted"] == 1
 
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
-        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
-        remaining_ns = {r["namespace"] for r in remaining}
-        assert remaining_ns == {"active_stream", "recent_stream"}
-    finally:
-        engine.dispose()
+    remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+    remaining_ns = {r["namespace"] for r in remaining}
+    assert remaining_ns == {"active_stream", "recent_stream"}
 
 
-def test_prune_checkpoints_include_active(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+def test_prune_checkpoints_include_active(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
 
-        old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "dead_ns", "shard-0", "50", True, old_ts)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "dead_ns", "shard-1", "60", False, old_ts)
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+    old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "dead_ns", "shard-0", "50", True, old_ts)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "dead_ns", "shard-1", "60", False, old_ts)
 
-        result = prune_checkpoints(
-            engine=engine,
-            older_than="7d",
-            namespace="dead_ns",
-            schema=TESTDRIVE_EXT_SCHEMA,
-            include_active=True,
-        )
-        assert result["deleted"] == 2
+    result = prune_checkpoints(
+        engine=engine,
+        older_than="7d",
+        namespace="dead_ns",
+        schema=TESTDRIVE_EXT_SCHEMA,
+        include_active=True,
+    )
+    assert result["deleted"] == 2
 
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
-        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
-        assert len(remaining) == 0
-    finally:
-        engine.dispose()
+    remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+    assert len(remaining) == 0
 
 
-def test_prune_checkpoints_by_namespace_only(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+def test_prune_checkpoints_by_namespace_only(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
 
-        ts = datetime.now(tz=timezone.utc) - timedelta(hours=1)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "keep_ns", "shard-0", "50", False, ts)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "remove_ns", "shard-0", "60", False, ts)
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+    ts = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "keep_ns", "shard-0", "50", False, ts)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "remove_ns", "shard-0", "60", False, ts)
 
-        result = prune_checkpoints(engine=engine, namespace="remove_ns", schema=TESTDRIVE_EXT_SCHEMA)
-        assert result["deleted"] == 1
+    result = prune_checkpoints(engine=engine, namespace="remove_ns", schema=TESTDRIVE_EXT_SCHEMA)
+    assert result["deleted"] == 1
 
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
-        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
-        assert len(remaining) == 1
-        assert remaining[0]["namespace"] == "keep_ns"
-    finally:
-        engine.dispose()
+    remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+    assert len(remaining) == 1
+    assert remaining[0]["namespace"] == "keep_ns"
 
 
-def test_prune_checkpoints_dry_run(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+def test_prune_checkpoints_dry_run(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
 
-        old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stale", "shard-0", "50", False, old_ts)
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+    old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stale", "shard-0", "50", False, old_ts)
 
-        result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA, dry_run=True)
-        assert result["would_delete"] == 1
+    result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA, dry_run=True)
+    assert result["would_delete"] == 1
 
-        # Row should still exist.
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
-        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
-        assert len(remaining) == 1
-    finally:
-        engine.dispose()
+    # Row should still exist.
+    remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+    assert len(remaining) == 1
 
 
-def test_prune_checkpoints_with_namespace_filter(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+def test_prune_checkpoints_with_namespace_filter(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
 
-        old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "keep_ns", "shard-0", "50", False, old_ts)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "prune_ns", "shard-0", "60", False, old_ts)
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+    old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "keep_ns", "shard-0", "50", False, old_ts)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "prune_ns", "shard-0", "60", False, old_ts)
 
-        result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA, namespace="prune_ns")
-        assert result["deleted"] == 1
+    result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA, namespace="prune_ns")
+    assert result["deleted"] == 1
 
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
-        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
-        assert len(remaining) == 1
-        assert remaining[0]["namespace"] == "keep_ns"
-    finally:
-        engine.dispose()
+    remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+    assert len(remaining) == 1
+    assert remaining[0]["namespace"] == "keep_ns"
 
 
-def test_prune_checkpoints_nothing_to_delete(cratedb):
-    engine = sa.create_engine(cratedb.get_connection_url())
-    try:
-        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+def test_prune_checkpoints_nothing_to_delete(cratedb_synchronized):
+    engine = cratedb_synchronized.database.engine
+    _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
 
-        recent_ts = datetime.now(tz=timezone.utc) - timedelta(hours=1)
-        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "recent", "shard-0", "100", False, recent_ts)
-        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+    recent_ts = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "recent", "shard-0", "100", False, recent_ts)
 
-        result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA)
-        assert result["deleted"] == 0
-    finally:
-        engine.dispose()
+    result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA)
+    assert result["deleted"] == 0

--- a/tests/io/test_kinesis_maintenance.py
+++ b/tests/io/test_kinesis_maintenance.py
@@ -1,0 +1,349 @@
+# Copyright (c) 2021-2025, Crate.io Inc.
+# Distributed under the terms of the AGPLv3 license, see LICENSE.
+"""
+Tests for Kinesis checkpoint maintenance operations.
+
+Placed outside ``tests/io/kinesis/`` to avoid the ``importorskip("kinesis")``
+gate in that package's conftest. These tests only need CrateDB (via
+testcontainer), not LocalStack or async-kinesis.
+"""
+
+import typing as t
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import sqlalchemy as sa
+
+from cratedb_toolkit.exception import CheckpointTableNotFound
+from cratedb_toolkit.io.kinesis.maintenance import (
+    TABLE_NAME,
+    list_checkpoints,
+    parse_duration,
+    prune_checkpoints,
+)
+from tests.conftest import TESTDRIVE_EXT_SCHEMA
+
+pytestmark = pytest.mark.kinesis
+
+
+def _create_checkpoint_table(engine: sa.Engine, schema: str) -> None:
+    """Create the checkpoint table matching the CrateDBCheckPointer layout."""
+    table = f'"{schema}"."{TABLE_NAME}"'
+    ddl = f"""
+        CREATE TABLE IF NOT EXISTS {table} (
+            "namespace" TEXT NOT NULL,
+            "shard_id"  TEXT NOT NULL,
+            "sequence"  TEXT,
+            "active"    BOOLEAN DEFAULT TRUE,
+            "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY ("namespace", "shard_id")
+        )
+    """
+    with engine.connect() as conn:
+        conn.execute(sa.text(ddl))
+        conn.commit()
+
+
+def _insert_checkpoint(
+    engine: sa.Engine,
+    schema: str,
+    namespace: str,
+    shard_id: str,
+    sequence: str,
+    active: bool,
+    updated_at: t.Optional[datetime] = None,
+) -> None:
+    """Insert a checkpoint row with an explicit updated_at timestamp."""
+    table = f'"{schema}"."{TABLE_NAME}"'
+    sql = sa.text(
+        f'INSERT INTO {table} ("namespace", "shard_id", "sequence", "active", "updated_at") '  # noqa: S608
+        "VALUES (:ns, :shard, :seq, :active, :ts)"
+    )
+    ts = updated_at or datetime.now(tz=timezone.utc)
+    with engine.connect() as conn:
+        conn.execute(sql, {"ns": namespace, "shard": shard_id, "seq": sequence, "active": active, "ts": ts})
+        conn.commit()
+
+
+def _refresh_table(engine: sa.Engine, schema: str) -> None:
+    """Flush CrateDB write buffer so rows are visible to subsequent queries."""
+    table = f'"{schema}"."{TABLE_NAME}"'
+    with engine.connect() as conn:
+        conn.execute(sa.text(f"REFRESH TABLE {table}"))
+
+
+# -- parse_duration tests (pure, no DB) --
+
+
+def test_parse_duration_days():
+    assert parse_duration("7d") == timedelta(days=7)
+
+
+def test_parse_duration_hours():
+    assert parse_duration("24h") == timedelta(hours=24)
+
+
+def test_parse_duration_minutes():
+    assert parse_duration("30m") == timedelta(minutes=30)
+
+
+def test_parse_duration_seconds():
+    assert parse_duration("90s") == timedelta(seconds=90)
+
+
+def test_parse_duration_weeks():
+    assert parse_duration("2w") == timedelta(weeks=2)
+
+
+def test_parse_duration_combined():
+    assert parse_duration("1d12h") == timedelta(days=1, hours=12)
+
+
+def test_parse_duration_full_combination():
+    assert parse_duration("1w2d3h15m30s") == timedelta(weeks=1, days=2, hours=3, minutes=15, seconds=30)
+
+
+def test_parse_duration_whitespace_stripped():
+    assert parse_duration("  7d  ") == timedelta(days=7)
+
+
+def test_parse_duration_invalid_format():
+    with pytest.raises(ValueError, match="Invalid duration"):
+        parse_duration("seven days")
+
+
+def test_parse_duration_empty_string():
+    with pytest.raises(ValueError, match="Invalid duration"):
+        parse_duration("")
+
+
+def test_parse_duration_zero():
+    with pytest.raises(ValueError, match="must be positive"):
+        parse_duration("0d")
+
+
+# -- list_checkpoints tests --
+
+
+def test_list_checkpoints_table_not_found(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        with pytest.raises(CheckpointTableNotFound, match="does not exist"):
+            list_checkpoints(engine=engine, schema="nonexistent_schema")
+    finally:
+        engine.dispose()
+
+
+def test_list_checkpoints_empty_table(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+        rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+        assert rows == []
+    finally:
+        engine.dispose()
+
+
+def test_list_checkpoints_all(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_a", "shard-0", "100", True)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_b", "shard-0", "200", False)
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+        assert len(rows) == 2
+        namespaces = {r["namespace"] for r in rows}
+        assert namespaces == {"stream_a", "stream_b"}
+    finally:
+        engine.dispose()
+
+
+def test_list_checkpoints_filter_by_namespace(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_a", "shard-0", "100", True)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stream_b", "shard-0", "200", False)
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA, namespace="stream_a")
+        assert len(rows) == 1
+        assert rows[0]["namespace"] == "stream_a"
+    finally:
+        engine.dispose()
+
+
+def test_list_checkpoints_result_keys(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "ns", "shard-0", "100", True)
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        rows = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+        assert len(rows) == 1
+        assert set(rows[0].keys()) == {"namespace", "shard_id", "sequence", "active", "updated_at"}
+    finally:
+        engine.dispose()
+
+
+# -- prune_checkpoints tests --
+
+
+def test_prune_checkpoints_table_not_found(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        with pytest.raises(CheckpointTableNotFound, match="does not exist"):
+            prune_checkpoints(engine=engine, older_than="7d", schema="nonexistent_schema")
+    finally:
+        engine.dispose()
+
+
+def test_prune_checkpoints_invalid_duration(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        with pytest.raises(ValueError, match="Invalid duration"):
+            prune_checkpoints(engine=engine, older_than="abc", schema=TESTDRIVE_EXT_SCHEMA)
+    finally:
+        engine.dispose()
+
+
+def test_prune_checkpoints_requires_filter(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        with pytest.raises(ValueError, match="At least one"):
+            prune_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+    finally:
+        engine.dispose()
+
+
+def test_prune_checkpoints_inactive_old_rows(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
+        recent_ts = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+
+        # Old inactive (should be pruned).
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "old_stream", "shard-0", "50", False, old_ts)
+        # Old active (should NOT be pruned).
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "active_stream", "shard-0", "100", True, old_ts)
+        # Recent inactive (should NOT be pruned).
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "recent_stream", "shard-0", "200", False, recent_ts)
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA)
+        assert result["deleted"] == 1
+
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+        remaining_ns = {r["namespace"] for r in remaining}
+        assert remaining_ns == {"active_stream", "recent_stream"}
+    finally:
+        engine.dispose()
+
+
+def test_prune_checkpoints_include_active(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "dead_ns", "shard-0", "50", True, old_ts)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "dead_ns", "shard-1", "60", False, old_ts)
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        result = prune_checkpoints(
+            engine=engine,
+            older_than="7d",
+            namespace="dead_ns",
+            schema=TESTDRIVE_EXT_SCHEMA,
+            include_active=True,
+        )
+        assert result["deleted"] == 2
+
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+        assert len(remaining) == 0
+    finally:
+        engine.dispose()
+
+
+def test_prune_checkpoints_by_namespace_only(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        ts = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "keep_ns", "shard-0", "50", False, ts)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "remove_ns", "shard-0", "60", False, ts)
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        result = prune_checkpoints(engine=engine, namespace="remove_ns", schema=TESTDRIVE_EXT_SCHEMA)
+        assert result["deleted"] == 1
+
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+        assert len(remaining) == 1
+        assert remaining[0]["namespace"] == "keep_ns"
+    finally:
+        engine.dispose()
+
+
+def test_prune_checkpoints_dry_run(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "stale", "shard-0", "50", False, old_ts)
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA, dry_run=True)
+        assert result["would_delete"] == 1
+
+        # Row should still exist.
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+        assert len(remaining) == 1
+    finally:
+        engine.dispose()
+
+
+def test_prune_checkpoints_with_namespace_filter(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        old_ts = datetime.now(tz=timezone.utc) - timedelta(days=10)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "keep_ns", "shard-0", "50", False, old_ts)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "prune_ns", "shard-0", "60", False, old_ts)
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA, namespace="prune_ns")
+        assert result["deleted"] == 1
+
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+        remaining = list_checkpoints(engine=engine, schema=TESTDRIVE_EXT_SCHEMA)
+        assert len(remaining) == 1
+        assert remaining[0]["namespace"] == "keep_ns"
+    finally:
+        engine.dispose()
+
+
+def test_prune_checkpoints_nothing_to_delete(cratedb):
+    engine = sa.create_engine(cratedb.get_connection_url())
+    try:
+        _create_checkpoint_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        recent_ts = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        _insert_checkpoint(engine, TESTDRIVE_EXT_SCHEMA, "recent", "shard-0", "100", False, recent_ts)
+        _refresh_table(engine, TESTDRIVE_EXT_SCHEMA)
+
+        result = prune_checkpoints(engine=engine, older_than="7d", schema=TESTDRIVE_EXT_SCHEMA)
+        assert result["deleted"] == 0
+    finally:
+        engine.dispose()

--- a/tests/io/test_kinesis_maintenance.py
+++ b/tests/io/test_kinesis_maintenance.py
@@ -64,8 +64,6 @@ def _insert_checkpoint(
         conn.commit()
 
 
-
-
 # -- list_checkpoints tests --
 
 

--- a/tests/util/test_date.py
+++ b/tests/util/test_date.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2021-2025, Crate.io Inc.
+# Distributed under the terms of the AGPLv3 license, see LICENSE.
+"""
+Tests for date/duration utility functions.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from cratedb_toolkit.util.date import parse_duration
+
+
+def test_parse_duration_days():
+    assert parse_duration("7d") == timedelta(days=7)
+
+
+def test_parse_duration_hours():
+    assert parse_duration("24h") == timedelta(hours=24)
+
+
+def test_parse_duration_minutes():
+    assert parse_duration("30m") == timedelta(minutes=30)
+
+
+def test_parse_duration_seconds():
+    assert parse_duration("90s") == timedelta(seconds=90)
+
+
+def test_parse_duration_weeks():
+    assert parse_duration("2w") == timedelta(weeks=2)
+
+
+def test_parse_duration_combined():
+    assert parse_duration("1d12h") == timedelta(days=1, hours=12)
+
+
+def test_parse_duration_full_combination():
+    assert parse_duration("1w2d3h15m30s") == timedelta(weeks=1, days=2, hours=3, minutes=15, seconds=30)
+
+
+def test_parse_duration_whitespace_stripped():
+    assert parse_duration("  7d  ") == timedelta(days=7)
+
+
+def test_parse_duration_invalid_format():
+    with pytest.raises(ValueError, match="Invalid duration"):
+        parse_duration("seven days")
+
+
+def test_parse_duration_empty_string():
+    with pytest.raises(ValueError, match="Invalid duration"):
+        parse_duration("")
+
+
+def test_parse_duration_zero():
+    with pytest.raises(ValueError, match="must be positive"):
+        parse_duration("0d")


### PR DESCRIPTION
## Summary
- Add `ctk kinesis list-checkpoints` and `ctk kinesis prune-checkpoints` commands for checkpoint table maintenance
- Decoupled from `async-kinesis` so the CLI works without the optional `[kinesis]` extra installed
- Follows up on PR #728 review comment about checkpoint table lifecycle/pruning

## Changes
- `cratedb_toolkit/io/kinesis/maintenance.py` (standalone functions for listing and pruning checkpoint rows (pure SQL, no async-kinesis dependency)
- `cratedb_toolkit/io/kinesis/cli.py`) Click CLI group registered as `ctk kinesis` with `list-checkpoints` (alias `ls`) and `prune-checkpoints` (alias `prune`)
- `cratedb_toolkit/exception.py` (`CheckpointTableNotFound` exception
- `cratedb_toolkit/cli.py`) register the new `kinesis` subcommand group
- `doc/io/stream/kinesis.md` (CLI usage documentation
- `CHANGES.md`) changelog entry

### Safety model
- Prune only deletes `active=FALSE` rows by default; `--include-active` flag for decommissioned namespace cleanup
- `--dry-run` previews deletions without executing
- Interactive confirmation prompt unless `--yes` is passed
- At least one filter (`--older-than` or `--namespace`) is required

## Test plan
- [x] 25 unit/integration tests covering duration parsing, list/prune operations, dry-run, namespace filtering, include-active, edge cases
- [x] All tests pass against CrateDB testcontainer
- [x] `ruff check` and `ruff format` clean
- [x] CLI tested manually against live CrateDB container