### PR TITLE
Kinesis: Improve SQLAlchemy compatibility

### DIFF
--- a/cratedb_toolkit/docs/model.py
+++ b/cratedb_toolkit/docs/model.py
@@ -3,6 +3,8 @@ import logging
 
 import requests
 
+from cratedb_toolkit import __version__
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,7 +19,7 @@ class DocsItem:
     source_url: str
 
     def fetch(self) -> str:
-        response = requests.get(self.source_url, timeout=10)
+        response = requests.get(self.source_url, headers={"User-Agent": f"ctk/{__version__}"}, timeout=10)
         if response.status_code != 200:
             logger.error(
                 f"Failed to fetch documentation from {self.source_url}: HTTP {response.status_code}\n{response.text}"

--- a/cratedb_toolkit/io/kinesis/checkpointer.py
+++ b/cratedb_toolkit/io/kinesis/checkpointer.py
@@ -36,7 +36,7 @@ class CrateDBCheckPointer(BaseCheckPointer):
 
     def __init__(
         self,
-        engine: sa.Engine,
+        engine: sa.engine.Engine,
         name: str,
         schema: str = "ext",
         consumer_id: t.Union[str, int, None] = None,

--- a/cratedb_toolkit/io/kinesis/maintenance.py
+++ b/cratedb_toolkit/io/kinesis/maintenance.py
@@ -38,7 +38,7 @@ def _qualified_table(schema: str) -> str:
     return f'"{schema}"."{TABLE_NAME}"'
 
 
-def _check_table_exists(conn: sa.Connection, schema: str) -> None:
+def _check_table_exists(conn: sa.engine.Connection, schema: str) -> None:
     """Raise ``CheckpointTableNotFound`` if the checkpoint table does not exist."""
     result = conn.execute(
         sa.text("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = :schema AND table_name = :table"),
@@ -49,7 +49,7 @@ def _check_table_exists(conn: sa.Connection, schema: str) -> None:
 
 
 def list_checkpoints(
-    engine: sa.Engine,
+    engine: sa.engine.Engine,
     schema: str = "ext",
     namespace: t.Optional[str] = None,
 ) -> t.List[t.Dict[str, t.Any]]:
@@ -79,7 +79,7 @@ def list_checkpoints(
 
 
 def prune_checkpoints(
-    engine: sa.Engine,
+    engine: sa.engine.Engine,
     schema: str = "ext",
     older_than: t.Optional[str] = None,
     namespace: t.Optional[str] = None,

--- a/cratedb_toolkit/io/kinesis/relay.py
+++ b/cratedb_toolkit/io/kinesis/relay.py
@@ -59,7 +59,7 @@ class KinesisRelay:
         else:
             raise SkipAdapterException(f"Not processing {self.kinesis_url} here")
 
-        self.connection: sa.Connection
+        self.connection: sa.engine.Connection
         self.progress_bar: tqdm
 
     def _setup_checkpointer(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -421,14 +421,14 @@ tasks.format = [
   # Format code.
   # Configure Ruff not to auto-fix a few items that are useful in workbench mode.
   # e.g.: unused imports (F401), unused variables (F841), `print` statements (T201), commented-out code (ERA001)
-  { cmd = "ruff format" },
+  { cmd = "ruff format --exclude examples" },
   { cmd = "ruff check --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 --ignore=ERA001" },
   # Format examples.
   # Use `black` for the files in `examples/*`, because it knows how to treat Jupyter files well.
   { cmd = "black examples" },
 ]
 tasks.lint = [
-  { cmd = "ruff format --check" },
+  { cmd = "ruff format --exclude examples --check" },
   { cmd = "ruff check" },
   { cmd = "validate-pyproject pyproject.toml" },
   { cmd = "ty check" },

--- a/tests/io/kinesis/test_relay.py
+++ b/tests/io/kinesis/test_relay.py
@@ -87,7 +87,7 @@ def test_kinesis_relay_write_failure_propagates(caplog, cratedb, kinesis):
         table_loader.kinesis_adapter.produce(event)
 
     # Patch connection.execute to raise OperationalError on the INSERT (not the DDL).
-    original_execute = sa.Connection.execute
+    original_execute = sa.engine.Connection.execute
 
     def failing_execute(self, statement, *args, **kwargs):
         stmt_text = statement.text if hasattr(statement, "text") else str(statement)
@@ -96,7 +96,7 @@ def test_kinesis_relay_write_failure_propagates(caplog, cratedb, kinesis):
         return original_execute(self, statement, *args, **kwargs)
 
     # Verify that the write failure propagates instead of being swallowed.
-    with patch.object(sa.Connection, "execute", failing_execute):
+    with patch.object(sa.engine.Connection, "execute", failing_execute):
         with pytest.raises(OperationalError, match="connection lost"):
             table_loader.start(once=True)
 

--- a/tests/io/test_kinesis_maintenance.py
+++ b/tests/io/test_kinesis_maintenance.py
@@ -25,7 +25,7 @@ from tests.conftest import TESTDRIVE_EXT_SCHEMA
 pytestmark = pytest.mark.kinesis
 
 
-def _create_checkpoint_table(engine: sa.Engine, schema: str) -> None:
+def _create_checkpoint_table(engine: sa.engine.Engine, schema: str) -> None:
     """Create the checkpoint table matching the CrateDBCheckPointer layout."""
     table = f'"{schema}"."{TABLE_NAME}"'
     ddl = f"""
@@ -44,7 +44,7 @@ def _create_checkpoint_table(engine: sa.Engine, schema: str) -> None:
 
 
 def _insert_checkpoint(
-    engine: sa.Engine,
+    engine: sa.engine.Engine,
     schema: str,
     namespace: str,
     shard_id: str,


### PR DESCRIPTION
It is unlikely we will use this with SQLAlchemy 1.x, which is only needed to support the **ingestr-based** I/O subsystem, so I've fixed CI with. /cc @hampsterx

The patch also includes two other chores.