### PR TITLE
Installed `curl` into the OCI image, for Compose health checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Installed `curl` into the OCI image, for Compose health checks
 
 ## 2026/04/27 v0.0.47
 - Kinesis: Added `ctk kinesis` CLI group with `list-checkpoints` and

--- a/release/oci-full/Dockerfile
+++ b/release/oci-full/Dockerfile
@@ -78,6 +78,14 @@ RUN \
     && WHEEL="$(ls /tmp/*.whl)" \
     && uv tool install --upgrade "cratedb-toolkit[full] @ file://${WHEEL}"
 
+# Install curl, for running Compose health checks.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,id=apt-cache-${TARGETARCH}${TARGETVARIANT},target=/var/cache/apt \
+    --mount=type=cache,id=apt-lists-${TARGETARCH}${TARGETVARIANT},target=/var/lib/apt \
+    true \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests --yes curl
+
 # Copy `selftest.sh` to the image.
 COPY release/oci-full/selftest.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/selftest.sh

--- a/release/oci-ingest/Dockerfile
+++ b/release/oci-ingest/Dockerfile
@@ -124,6 +124,14 @@ RUN \
     && WHEEL="$(ls /tmp/*.whl)" \
     && uv pip install --overrides="/tmp/overrides.txt" "ingestr[oracle,odbc]" "cratedb-toolkit[io-ingest] @ file://${WHEEL}"
 
+# Install curl, for running Compose health checks.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,id=apt-cache-${TARGETARCH}${TARGETVARIANT},target=/var/cache/apt \
+    --mount=type=cache,id=apt-lists-${TARGETARCH}${TARGETVARIANT},target=/var/lib/apt \
+    true \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests --yes curl
+
 # Copy `selftest.sh` to the image.
 COPY release/oci-ingest/selftest.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/selftest.sh


### PR DESCRIPTION
`curl` is needed for doing Compose health checks.

```diff
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:4242"]
+      start_period: 3s
+      interval: 1.5s
+      retries: 30
+      timeout: 30s
```
