### PR TITLE
I/O: Add option to submit workloads to remote Dask clusters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Installed `curl` into the OCI image, for Compose health checks
 - Added `session_id` attribute to `SysJobsLog`, to accompany newer CrateDB versions
+- I/O: Added option to submit workloads to remote Dask clusters
 
 ## 2026/04/27 v0.0.47
 - Kinesis: Added `ctk kinesis` CLI group with `list-checkpoints` and

--- a/cratedb_toolkit/cluster/compute.py
+++ b/cratedb_toolkit/cluster/compute.py
@@ -1,0 +1,26 @@
+import functools
+
+
+def function(f):
+    """Execute a function on a compute cluster."""
+
+    # Wrap payload function into being submitted to a dask worker.
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        address = None
+        try:
+            import dask
+
+            address = dask.config.get("scheduler-address", None)
+        except ImportError:
+            pass
+        if address is None:
+            # No remote scheduler configured; invoke directly without Dask overhead.
+            return f(*args, **kwargs)
+
+        from dask.distributed import Client
+
+        with Client(address) as client:
+            return client.submit(f, *args, **kwargs).result()
+
+    return wrapper

--- a/cratedb_toolkit/io/router.py
+++ b/cratedb_toolkit/io/router.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from boltons.urlutils import URL
 
+from cratedb_toolkit.cluster import compute
 from cratedb_toolkit.exception import (
     OperationFailed,
 )
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 class IoRouter:
+    @compute.function
     def load_table(
         self,
         source: InputOutputResource,
@@ -127,6 +129,7 @@ class IoRouter:
         else:
             raise NotImplementedError(f"Importing resource not implemented yet: {source_url_obj}")
 
+    @compute.function
     def save_table(
         self,
         source: DatabaseAddress,

--- a/doc/io/index.md
+++ b/doc/io/index.md
@@ -193,6 +193,15 @@ to load the entire table every time you run the data migration procedure.
 This comes at a minor cost that a few bookkeeping columns exist in the target
 table, however that is rarely an issue.
 
+:::{rubric} Remote scheduling
+:::
+
+To schedule your workload on a remote dask cluster, define the
+`DASK_SCHEDULER_ADDRESS` environment variable.
+```shell
+export DASK_SCHEDULER_ADDRESS='tcp://127.0.0.1:8786'
+```
+
 (io-coverage)=
 ## Coverage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ optional-dependencies.io = [
 ]
 optional-dependencies.io-base = [
   "cr8",
-  "dask[dataframe]>=2020",
+  "dask[dataframe,distributed]>=2020",
   "fsspec[http,s3]",
   "pandas>=1,<3.1",
   "polars<1.41",


### PR DESCRIPTION
## About
For heavy I/O tasks, let's give users the option to schedule them on remote workers, effectively providing important details of [remoting](https://en.wikipedia.org/wiki/Remoting) and [serverless](https://en.wikipedia.org/wiki/Serverless).

## References
- https://github.com/crate/cratedb-examples/pull/1676#pullrequestreview-4215223578

## Documentation
- Current: https://distributed.dask.org/en/stable/quickstart.html
- Outlook: https://docs.coiled.io/user_guide/functions.html