### PR TITLE
CI: Maintenance 20260512

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Installed `curl` into the OCI image, for Compose health checks
+- Added `session_id` attribute to `SysJobsLog`, to accompany newer CrateDB versions
 
 ## 2026/04/27 v0.0.47
 - Kinesis: Added `ctk kinesis` CLI group with `list-checkpoints` and

--- a/cratedb_toolkit/cmd/tail/main.py
+++ b/cratedb_toolkit/cmd/tail/main.py
@@ -30,6 +30,7 @@ class SysJobsLog:
     error: str
     node: t.Dict[str, t.Any]
     username: str
+    session_id: t.Optional[str]
 
     @property
     def template(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -452,7 +452,7 @@ tasks.release = [
   { cmd = "python -m build" },
   { cmd = "twine upload --skip-existing dist/*" },
 ]
-tasks.test = { cmd = "pytest -m 'not postgresql'" }
+tasks.test = { cmd = "pytest -m 'not (influxdb or postgresql)'" }
 tasks.build-cfr = { cmd = "pyinstaller cratedb_toolkit/cfr/cli.py --onefile --name cratedb-cfr" }
 
 [tool.versioningit]

--- a/tests/io/influxdb/conftest.py
+++ b/tests/io/influxdb/conftest.py
@@ -4,6 +4,8 @@ import pytest
 
 from cratedb_toolkit.testing.testcontainers.util import PytestTestcontainerAdapter
 
+pytestmark = pytest.mark.influxdb
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Just a little maintenance to fix CI.

- [CI: Don't run InfluxDB tests on main CI workflow](https://github.com/crate/cratedb-toolkit/pull/795/commits/1df8f2ef56274e18186396ae45df7b794e45bf72)
- [Add session_id attribute to SysJobsLog, to accompany newer CrateDB](https://github.com/crate/cratedb-toolkit/pull/795/commits/1c6368d4e5479ce0280df4a49c54d2cc595a9f58)