### PR TITLE
Tests: Migrate DynamoDB and Kinesis emulator from LocalStack to Floci

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -6,7 +6,7 @@ on:
     paths:
     - '.github/workflows/dynamodb.yml'
     - 'cratedb_toolkit/io/dynamodb/**'
-    - 'cratedb_toolkit/testing/testcontainers/localstack.py'
+    - 'cratedb_toolkit/testing/testcontainers/floci.py'
     - 'cratedb_toolkit/testing/testcontainers/util.py'
     - 'tests/io/dynamodb/**'
     - 'pyproject.toml'
@@ -15,7 +15,7 @@ on:
     paths:
     - '.github/workflows/dynamodb.yml'
     - 'cratedb_toolkit/io/dynamodb/**'
-    - 'cratedb_toolkit/testing/testcontainers/localstack.py'
+    - 'cratedb_toolkit/testing/testcontainers/floci.py'
     - 'cratedb_toolkit/testing/testcontainers/util.py'
     - 'tests/io/dynamodb/**'
     - 'pyproject.toml'
@@ -45,19 +45,19 @@ jobs:
           "3.10",
           "3.14",
         ]
-        localstack-version:
-          - "4.14"
+        floci-version:
+          - "1.5.11"
 
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
-      LOCALSTACK_VERSION: ${{ matrix.localstack-version }}
+      FLOCI_VERSION: ${{ matrix.floci-version }}
       # Do not tear down Testcontainers
       TC_KEEPALIVE: true
 
     name: "
     Python ${{ matrix.python-version }}, 
-    LocalStack ${{ matrix.localstack-version }}, 
+    Floci ${{ matrix.floci-version }},
     OS ${{ matrix.os }}
     "
     steps:

--- a/.github/workflows/kinesis.yml
+++ b/.github/workflows/kinesis.yml
@@ -6,7 +6,7 @@ on:
     paths:
     - '.github/workflows/kinesis.yml'
     - 'cratedb_toolkit/io/kinesis/**'
-    - 'cratedb_toolkit/testing/testcontainers/localstack.py'
+    - 'cratedb_toolkit/testing/testcontainers/floci.py'
     - 'cratedb_toolkit/testing/testcontainers/util.py'
     - 'tests/io/kinesis/**'
     - 'pyproject.toml'
@@ -15,7 +15,7 @@ on:
     paths:
     - '.github/workflows/kinesis.yml'
     - 'cratedb_toolkit/io/kinesis/**'
-    - 'cratedb_toolkit/testing/testcontainers/localstack.py'
+    - 'cratedb_toolkit/testing/testcontainers/floci.py'
     - 'cratedb_toolkit/testing/testcontainers/util.py'
     - 'tests/io/kinesis/**'
     - 'pyproject.toml'

--- a/cratedb_toolkit/io/dynamodb/api.py
+++ b/cratedb_toolkit/io/dynamodb/api.py
@@ -17,7 +17,7 @@ def dynamodb_copy(source_url, target_url, progress: bool = False):
     ctk load dynamodb://arn:aws:dynamodb:us-east-1:000000000000:table/ProductCatalog
     ctk load dynamodb://arn:aws:dynamodb:us-east-1:841394475918:table/stream-demo
 
-    ctk load dynamodb://LSIAQAAAAAAVNCBMPNSG:dummy@localhost:4566/ProductCatalog?region=eu-central-1
+    ctk load dynamodb://AKIAIOSFODNN7EXAMPLE:dummy@localhost:4566/ProductCatalog?region=eu-central-1
 
     Resources
     ---------

--- a/cratedb_toolkit/testing/testcontainers/floci.py
+++ b/cratedb_toolkit/testing/testcontainers/floci.py
@@ -15,46 +15,56 @@ import re
 
 from testcontainers.core.wait_strategies import LogMessageWaitStrategy
 from testcontainers.core.waiting_utils import wait_for_logs
-from testcontainers.localstack import LocalStackContainer
 
 from cratedb_toolkit.testing.testcontainers.util import KeepaliveContainer
 
 
-class LocalStackContainerWithKeepalive(KeepaliveContainer, LocalStackContainer):
+class FlociContainerWithKeepalive(KeepaliveContainer):
     """
-    A Testcontainer for LocalStack with improved configurability.
+    A Testcontainer for Floci with improved configurability.
 
-    It honors the `TC_KEEPALIVE` and `LOCALSTACK_VERSION` environment variables.
+    It honors the `TC_KEEPALIVE` and `FLOCI_VERSION` environment variables.
 
     Defining `TC_KEEPALIVE` sets a signal to not shut down the container
     after running the test cases, to speed up later invocations.
 
-    `LOCALSTACK_VERSION` defines the designated LocalStack version, which is
-    useful when used within a test matrix.
+    `FLOCI_VERSION` defines the designated Floci version, which is useful when
+    used within a test matrix.
     """
 
-    LOCALSTACK_VERSION = os.environ.get("LOCALSTACK_VERSION", "4.14")
+    FLOCI_PORT = 4566
+    # Pinned to a released tag rather than `latest`. Floci is a young project;
+    # bump after verifying the Kinesis and DynamoDB suites pass against the new image.
+    FLOCI_VERSION = os.environ.get("FLOCI_VERSION", "1.5.11")
 
     def __init__(
         self,
-        image: str = f"localstack/localstack:{LOCALSTACK_VERSION}",
+        image: str = f"floci/floci:{FLOCI_VERSION}",
         **kwargs,
     ) -> None:
         super().__init__(image=image, **kwargs)
-        self.with_name("testcontainers-localstack")
+        self.with_name("testcontainers-floci")
+        self.with_exposed_ports(self.FLOCI_PORT)
 
     def _configure(self):
-        self.waiting_for(LogMessageWaitStrategy(re.compile(r"Ready\.\n")))
+        self.waiting_for(LogMessageWaitStrategy(re.compile(r"AWS Local Emulator Ready")))
 
     def _connect(self):
         """
-        Wait for LocalStack to be fully ready.
+        Wait for Floci to be fully ready.
 
         ``KeepaliveContainer.start()`` calls ``_configure()`` and ``_connect()``
-        hooks, bypassing ``LocalStackContainer.start()`` which normally waits for
-        the "Ready" log message. Without this, Kinesis and other service APIs
-        receive requests before LocalStack is ready.
+        hooks. Without this, Kinesis and DynamoDB service APIs can receive
+        requests before Floci is ready.
         """
         if not self._wait_strategy:
             raise ValueError("No wait strategy defined")
         wait_for_logs(self, predicate=self._wait_strategy, timeout=60)
+
+    def get_url(self) -> str:
+        """
+        Return the mapped Floci edge endpoint.
+        """
+        host = self.get_container_host_ip()
+        port = self.get_exposed_port(self.FLOCI_PORT)
+        return f"http://{host}:{port}"

--- a/doc/io/database/dynamodb/cdc.md
+++ b/doc/io/database/dynamodb/cdc.md
@@ -122,39 +122,36 @@ looks like that.
 export CRATEDB_CLUSTER_URL='crate://admin:dZ...6LqB@testdrive.eks1.eu-west-1.aws.cratedb.net:4200/?ssl=true'
 ```
 
-### LocalStack
+### Floci
 In order to exercise data transfers exclusively on your workstation, you can
-use LocalStack to run DynamoDB and Kinesis service surrogates locally. See
-also the [Get started with Kinesis on LocalStack] tutorial.
+use Floci to run DynamoDB and Kinesis service surrogates locally. See also the
+[Floci Kinesis documentation].
 
-For addressing a Kinesis Data Stream on LocalStack, use a command of that shape.
-See [Credentials for accessing LocalStack AWS API] for further information.
+For addressing a Kinesis Data Stream on Floci, use a command of that shape.
 ```shell
-ctk load "kinesis+dynamodb+cdc://LSIAQAAAAAAVNCBMPNSG:dummy@localhost:4566/cdc-stream?region=eu-central-1"
+ctk load "kinesis+dynamodb+cdc://AKIAIOSFODNN7EXAMPLE:dummy@localhost:4566/cdc-stream?region=eu-central-1"
 ```
 
 :::{tip}
-LocalStack is a cloud service emulator that runs in a single container on your
-laptop or in your CI environment. With LocalStack, you can run your AWS
+Floci is a cloud service emulator that runs in a single container on your
+laptop or in your CI environment. With Floci, you can run your AWS
 applications or Lambdas entirely on your local machine without connecting to
 a remote cloud provider.
 
-In order to invoke LocalStack on your workstation, you can use this Docker
+In order to invoke Floci on your workstation, you can use this Docker
 command.
 ```shell
 docker run \
   --rm -it \
+  --name floci \
   -p 127.0.0.1:4566:4566 \
-  -p 127.0.0.1:4510-4559:4510-4559 \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  localstack/localstack:latest
+  floci/floci:1.5.11
 ```
 :::
 
 
 [Change data capture for DynamoDB Streams]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
-[Credentials for accessing LocalStack AWS API]: https://docs.localstack.cloud/references/credentials/
-[Get started with Kinesis on LocalStack]: https://docs.localstack.cloud/user-guide/aws/kinesis/
+[Floci Kinesis documentation]: https://floci.io/floci/services/kinesis/
 [Kinesis Data Streams]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/kds.html
 [SequenceNumber]: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetShardIterator.html#DDB-streams_GetShardIterator-request-SequenceNumber
 [ShardIteratorType]: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetShardIterator.html#DDB-streams_GetShardIterator-request-ShardIteratorType

--- a/doc/io/database/dynamodb/loader.md
+++ b/doc/io/database/dynamodb/loader.md
@@ -61,37 +61,34 @@ looks like that.
 export CRATEDB_CLUSTER_URL='crate://admin:dZ...6LqB@testdrive.eks1.eu-west-1.aws.cratedb.net:4200/?ssl=true'
 ```
 
-### LocalStack
+### Floci
 In order to exercise data transfers exclusively on your workstation, you can
-use LocalStack to run a DynamoDB service surrogate locally. See also the
-[Get started with DynamoDB on LocalStack] tutorial.
+use Floci to run a DynamoDB service surrogate locally. See also the
+[Floci DynamoDB documentation].
 
-For addressing a DynamoDB database on LocalStack, use a command of that shape.
-See [Credentials for accessing LocalStack AWS API] for further information.
+For addressing a DynamoDB database on Floci, use a command of that shape.
 ```shell
-ctk load "dynamodb://LSIAQAAAAAAVNCBMPNSG:dummy@localhost:4566/ProductCatalog?region=us-east-1"
+ctk load "dynamodb://AKIAIOSFODNN7EXAMPLE:dummy@localhost:4566/ProductCatalog?region=us-east-1"
 ```
 
 :::{tip}
-LocalStack is a cloud service emulator that runs in a single container on your
-laptop or in your CI environment. With LocalStack, you can run your AWS
+Floci is a cloud service emulator that runs in a single container on your
+laptop or in your CI environment. With Floci, you can run your AWS
 applications or Lambdas entirely on your local machine without connecting to
 a remote cloud provider.
 
-In order to invoke LocalStack on your workstation, you can use this Docker
+In order to invoke Floci on your workstation, you can use this Docker
 command.
 ```shell
 docker run \
   --rm -it \
+  --name floci \
   -p 127.0.0.1:4566:4566 \
-  -p 127.0.0.1:4510-4559:4510-4559 \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  localstack/localstack:latest
+  floci/floci:1.5.11
 ```
 :::
 
 
-[Credentials for accessing LocalStack AWS API]: https://docs.localstack.cloud/references/credentials/
-[Get started with DynamoDB on LocalStack]: https://docs.localstack.cloud/user-guide/aws/dynamodb/
+[Floci DynamoDB documentation]: https://floci.io/floci/services/dynamodb/
 [pagination]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination
 [read consistency]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ReadConsistency

--- a/doc/io/stream/kinesis.md
+++ b/doc/io/stream/kinesis.md
@@ -13,7 +13,7 @@ Load data from Amazon Kinesis into CrateDB.
 
 Use Docker or Podman to run all components. This approach works consistently
 across Linux, macOS, and Windows.
-The tutorial uses [LocalStack] to spin up a local instance of Amazon Kinesis so
+The tutorial uses [Floci] to spin up a local instance of Amazon Kinesis so
 you don't need an AWS account to exercise the pipeline.
 
 ## Install
@@ -30,11 +30,11 @@ to work with Amazon Kinesis and CrateDB.
 
 ### Services
 
-Run Kinesis from LocalStack and CrateDB using Docker or Podman.
+Run Kinesis from Floci and CrateDB using Docker or Podman.
 ```shell
-docker run --rm --name=localstack \
+docker run --rm --name=floci \
   --publish=4566:4566 \
-  docker.io/localstack/localstack:latest
+  docker.io/floci/floci:1.5.11
 ```
 ```shell
 docker run --rm --name=cratedb \
@@ -44,7 +44,7 @@ docker run --rm --name=cratedb \
 
 ### Configure AWS clients
 
-LocalStack's default region is `us-east-1`. Let's use it.
+Floci's default region is `us-east-1`. Let's use it.
 ```shell
 export AWS_DEFAULT_REGION=us-east-1
 export AWS_ENDPOINT_URL="http://localhost:4566"
@@ -262,7 +262,7 @@ AND "updated_at" < NOW() - INTERVAL '30 days';
 [ARN]: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
 [awscli]: https://pypi.org/project/awscli/
 [cratedb-toolkit]: https://pypi.org/project/cratedb-toolkit/
-[LocalStack]: https://www.localstack.cloud/
+[Floci]: https://github.com/floci-io/floci
 [StartingPosition]: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_StartingPosition.html
 [streams]: https://aws.amazon.com/what-is/streaming-data/
 [StreamARN]: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_StreamDescription.html#Streams-Type-StreamDescription-StreamARN

--- a/examples/cdc/aws/kinesis_put.py
+++ b/examples/cdc/aws/kinesis_put.py
@@ -9,9 +9,9 @@ from cratedb_toolkit.io.kinesis.adapter import KinesisStreamAdapter
 def main():
 
     # Address of the Kinesis stream.
-    # Note: Credentials and region are suitable for use with LocalStack ootb.
+    # Note: Credentials and region are suitable for use with Floci out of the box.
     # It is acceptable for local development examples, so please adjust when diverting to streams on AWS.
-    kinesis_url = URL("kinesis://LSIAQAAAAAAVNCBMPNSG:dummy@localhost:4566/cdc-stream?region=eu-central-1")
+    kinesis_url = URL("kinesis://AKIAIOSFODNN7EXAMPLE:dummy@localhost:4566/cdc-stream?region=eu-central-1")
 
     # DynamoDB CDC data payload example.
     data = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ optional-dependencies.io-recipe = [
 optional-dependencies.kinesis = [
   "aiobotocore<3.8",
   "async-kinesis>=2.4.0,<3",
+  "boto3",
   "botocore<1.44",
   "commons-codec>=0.0.24",
   "cratedb-toolkit[io-recipe]",
@@ -270,7 +271,7 @@ optional-dependencies.test = [
   "pueblo[dataframe,notebook,testing]>=0.0.11",
   "pydantic-core<3",
   "responses<0.27",
-  "testcontainers[azurite,localstack,minio,postgres]",
+  "testcontainers[azurite,minio,postgres]",
   "types-docutils<0.23",
 ]
 optional-dependencies.test-mongodb = [

--- a/tests/io/dynamodb/README.md
+++ b/tests/io/dynamodb/README.md
@@ -1,7 +1,7 @@
 # Testing DynamoDB
 
 ## About
-This unit-/integration test subsystem uses LocalStack's DynamoDB.
+This unit-/integration test subsystem uses Floci's DynamoDB.
 
 ## Resources
 - https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/AppendixSampleTables.html

--- a/tests/io/dynamodb/conftest.py
+++ b/tests/io/dynamodb/conftest.py
@@ -26,15 +26,15 @@ RESET_TABLES = [
 
 class DynamoDBFixture:
     """
-    A little helper wrapping Testcontainer's ``LocalStackContainer``.
+    A little helper wrapping Testcontainer's Floci container.
 
-    TODO: Generalize into ``LocalStackFixture``, see also ``tests.io.kinesis.conftest.KinesisFixture``.
+    TODO: Generalize into ``FlociFixture``, see also ``tests.io.kinesis.conftest.KinesisFixture``.
     """
 
     def __init__(self):
-        from cratedb_toolkit.testing.testcontainers.localstack import LocalStackContainerWithKeepalive
+        from cratedb_toolkit.testing.testcontainers.floci import FlociContainerWithKeepalive
 
-        self.container: LocalStackContainerWithKeepalive
+        self.container: FlociContainerWithKeepalive
         self.url = None
         self.dynamodb_adapter: DynamoDBAdapter
         self._stream_name = f"demo-{uuid.uuid4().hex[:8]}"
@@ -42,10 +42,9 @@ class DynamoDBFixture:
 
     def setup(self):
         # TODO: Make image name configurable.
-        from cratedb_toolkit.testing.testcontainers.localstack import LocalStackContainerWithKeepalive
+        from cratedb_toolkit.testing.testcontainers.floci import FlociContainerWithKeepalive
 
-        self.container = LocalStackContainerWithKeepalive()
-        self.container.with_services("dynamodb", "kinesis")
+        self.container = FlociContainerWithKeepalive()
         self.container.start()
 
         self.dynamodb_adapter = DynamoDBAdapter(URL(f"{self.get_connection_url_dynamodb()}?region=us-east-1"))
@@ -58,7 +57,7 @@ class DynamoDBFixture:
         """
         Provide each test case with a fresh canvas by assigning a unique stream name.
 
-        This avoids the delete/recreate race condition with LocalStack's eventual
+        This avoids the delete/recreate race condition with emulator eventual
         consistency, where ``create_stream`` can fail if called too soon after
         ``delete_stream`` completes.
         """
@@ -81,11 +80,11 @@ class DynamoDBFixture:
 
     def get_connection_url_dynamodb(self):
         url = URL(self.container.get_url())
-        return f"dynamodb://LSIAQAAAAAAVNCBMPNSG:dummy@{url.host}:{url.port}"
+        return f"dynamodb://AKIAIOSFODNN7EXAMPLE:dummy@{url.host}:{url.port}"
 
     def get_connection_url_kinesis_dynamodb_cdc(self):
         url = URL(self.container.get_url())
-        return f"kinesis+dynamodb+cdc://LSIAQAAAAAAVNCBMPNSG:dummy@{url.host}:{url.port}/{self._stream_name}"
+        return f"kinesis+dynamodb+cdc://AKIAIOSFODNN7EXAMPLE:dummy@{url.host}:{url.port}/{self._stream_name}"
 
 
 @pytest.fixture(scope="session")

--- a/tests/io/kinesis/conftest.py
+++ b/tests/io/kinesis/conftest.py
@@ -18,15 +18,15 @@ logger = logging.getLogger(__name__)
 
 class KinesisFixture:
     """
-    A little helper wrapping Testcontainer's `LocalStackContainer`.
+    A little helper wrapping Testcontainer's Floci container.
 
-    TODO: Generalize into `LocalStackFixture`, see also `tests.io.dynamodb.conftest.DynamoDBFixture`.
+    TODO: Generalize into `FlociFixture`, see also `tests.io.dynamodb.conftest.DynamoDBFixture`.
     """
 
     def __init__(self):
-        from cratedb_toolkit.testing.testcontainers.localstack import LocalStackContainerWithKeepalive
+        from cratedb_toolkit.testing.testcontainers.floci import FlociContainerWithKeepalive
 
-        self.container: LocalStackContainerWithKeepalive
+        self.container: FlociContainerWithKeepalive
         self.url = None
         self.kinesis_adapter: typing.Union[KinesisStreamAdapter, None] = None
         self._stream_name = "testdrive"
@@ -34,10 +34,9 @@ class KinesisFixture:
 
     def setup(self):
         # TODO: Make image name configurable.
-        from cratedb_toolkit.testing.testcontainers.localstack import LocalStackContainerWithKeepalive
+        from cratedb_toolkit.testing.testcontainers.floci import FlociContainerWithKeepalive
 
-        self.container = LocalStackContainerWithKeepalive()
-        self.container.with_services("kinesis")
+        self.container = FlociContainerWithKeepalive()
         self.container.start()
 
         self.kinesis_adapter = KinesisStreamAdapter(URL(f"{self.get_connection_url_kinesis()}?region=us-east-1"))
@@ -49,7 +48,7 @@ class KinesisFixture:
         """
         Provide each test case with a fresh canvas by assigning a unique stream name.
 
-        This avoids the delete/recreate race condition with LocalStack's eventual
+        This avoids the delete/recreate race condition with emulator eventual
         consistency, where ``create_stream`` can fail if called too soon after
         ``delete_stream`` completes.
         """
@@ -57,7 +56,7 @@ class KinesisFixture:
 
     def get_connection_url_kinesis(self):
         url = URL(self.container.get_url())
-        return f"kinesis+dms://LSIAQAAAAAAVNCBMPNSG:dummy@{url.host}:{url.port}/{self._stream_name}"
+        return f"kinesis+dms://AKIAIOSFODNN7EXAMPLE:dummy@{url.host}:{url.port}/{self._stream_name}"
 
 
 @pytest.fixture(scope="session")

--- a/tests/io/kinesis/test_checkpointer.py
+++ b/tests/io/kinesis/test_checkpointer.py
@@ -21,7 +21,7 @@ from tests.io.test_awslambda import wrap_kinesis
 TRANSFORMATION_FILE = Path("./examples/cdc/aws/dms-load-schema-universal.yaml")
 
 
-# -- Unit tests: CrateDB container only, no LocalStack --
+# -- Unit tests: CrateDB container only, no Floci --
 
 
 def test_cratedb_checkpointer_table_creation(cratedb):
@@ -207,7 +207,7 @@ def test_cratedb_checkpointer_get_all_checkpoints(cratedb):
         engine.dispose()
 
 
-# -- Integration tests: CrateDB + LocalStack --
+# -- Integration tests: CrateDB + Floci --
 
 
 def test_checkpointer_url_param_wiring(cratedb, kinesis):

--- a/tests/io/test_kinesis_maintenance.py
+++ b/tests/io/test_kinesis_maintenance.py
@@ -5,7 +5,7 @@ Tests for Kinesis checkpoint maintenance operations.
 
 Placed outside ``tests/io/kinesis/`` to avoid the ``importorskip("kinesis")``
 gate in that package's conftest. These tests only need CrateDB (via
-testcontainer), not LocalStack or async-kinesis.
+testcontainer), not Floci or async-kinesis.
 """
 
 import typing as t


### PR DESCRIPTION
## Summary

- LocalStack 4.14 is the last release that runs anonymously. The consolidated `localstack/localstack` image released after 2026-03-23 requires an auth token, and the temporary `LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1` bypass expired 2026-04-06. Bumping past 4.14 breaks anonymous CI and contributor local runs.
- Follow-up to #726, where @amotl suggested evaluating [Floci](https://github.com/floci-io/floci) as a FOSS alternative.
- Floci covers the test surface used here: Kinesis, DynamoDB, DynamoDB Streams, and DynamoDB-to-Kinesis relay. It listens on the same port (4566) and exposes a LocalStack-compatible health endpoint, so the integration surface stays the same.
- New `FlociContainerWithKeepalive` (in `cratedb_toolkit/testing/testcontainers/floci.py`) replaces `LocalStackContainerWithKeepalive`. No new Python testcontainers dependency: the wrapper is a raw `DockerContainer` subclass that keeps the existing `KeepaliveContainer` mixin. Floci starts the needed services itself, so the per-test `.with_services(...)` calls are gone.
- Image pinned to `floci/floci:1.5.11` (released tag, not `latest`). A short comment in `floci.py` calls out the rationale for future bumps.
- `pyproject.toml`: drop the `localstack` extra from `testcontainers[azurite,localstack,minio,postgres]`; promote `boto3` to a direct dep of `optional-dependencies.kinesis`. The Kinesis adapter does `import boto3` at module top. Before this PR, `boto3` arrived via the `localstack` extra of testcontainers. With that extra removed it still resolves transitively via `lorrystream[carabas]`, but the kinesis extra should declare it directly rather than rely on a 2-hop chain.
- Dummy AWS access key in docs/tests/examples switched from LocalStack-branded `LSIAQAAAAAAVNCBMPNSG` to the AWS-documented canonical example `AKIAIOSFODNN7EXAMPLE`. Floci accepts any 20-char key for unauthenticated dummy creds, so this is cosmetic but de-brands.
- CI workflows (`.github/workflows/{kinesis,dynamodb}.yml`): path filters and matrix env renamed from `LOCALSTACK_VERSION` to `FLOCI_VERSION`. DynamoDB workflow exposes a `floci-version` matrix pinned to `"1.5.11"`. Kinesis workflow uses the wrapper default.
- Docs (`doc/io/database/dynamodb/{cdc,loader}.md`, `doc/io/stream/kinesis.md`), example (`examples/cdc/aws/kinesis_put.py`), test README, and an internal docstring all updated.

## Test plan

- [x] `pytest tests/io/kinesis/test_relay.py::test_kinesis_earliest_dms_cdc_ddl_dml_universal` (local, against `floci/floci:1.5.11`)
- [x] `pytest tests/io/dynamodb/test_adapter.py::test_adapter_scan_success`
- [x] `pytest tests/io/kinesis/test_checkpointer.py::test_cratedb_checkpointer_integration`
- [x] `pytest tests/io/kinesis/test_cli.py::test_kinesis_dms_stream_universal`
- [x] Re-ran 3 focused tests after the dummy-key swap to confirm Floci accepts `AKIAIOSFODNN7EXAMPLE`
- [ ] Broad `pytest -m kinesis` and `pytest -m dynamodb` runs in CI on this branch

## Notes

- The wrapper currently waits on the Floci log marker `AWS Local Emulator Ready`. A future switch to a health-endpoint wait (`/_floci/health`) may be less brittle, but the log wait works reliably locally.
- Floci is still a young project. The pin to a released tag (not `latest`) and the in-code comment are deliberate: bump after verifying the suites pass against the new image.