### PR TITLE
Dependencies: Add `service` extra to `cfr` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ dependencies = [
   "yarl<1.25",
 ]
 optional-dependencies.cfr = [
+  "cratedb-toolkit[service]",
   "duckdb<2",
   "marimo<0.24",
   "matplotlib<3.11",


### PR DESCRIPTION
## Problem

> `ctk cfr jobstats ui` fails with `No module named 'fastapi'`.

## References

- GH-809
