### PR TITLE
Fix `ctk cfr info record` re. `Document contains immense term in field`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
   Thanks, @hammerhead.
 - Stopped failing `ctk cfr jobstats ui` when job statistics recordings are empty.
   Thanks, @hammerhead.
+- Fixed `ctk cfr info record` re. `Document contains at least one immense term in field`.
+  Thanks, @hammerhead.
 
 ## 2026/05/12 v0.0.48
 - OCI: Installed `curl`, for Compose health checks

--- a/cratedb_toolkit/cfr/info.py
+++ b/cratedb_toolkit/cfr/info.py
@@ -31,14 +31,36 @@ class InfoRecorder:
         jobinfo_sample = JobInfoContainer(adapter=self.adapter, scrub=self.scrub)
 
         for table, sample in ((self.clusterinfo_table, clusterinfo_sample), (self.jobinfo_table, jobinfo_sample)):
-            self.adapter.connection.execute(
-                sa.text(
-                    f"""
+            if table.endswith("jobinfo"):
+                sql = """
+                CREATE TABLE IF NOT EXISTS "ext"."jobinfo" (
+                   "time" TIMESTAMP WITHOUT TIME ZONE DEFAULT now(),
+                   "info" OBJECT(DYNAMIC) AS (
+                      "running" ARRAY(OBJECT(DYNAMIC) AS (
+                         "stmt" TEXT INDEX OFF STORAGE WITH (columnstore = false)
+                      )),
+                      "top100_duration_individual" ARRAY(OBJECT(DYNAMIC) AS (
+                         "stmt" TEXT INDEX OFF STORAGE WITH (columnstore = false)
+                      )),
+                      "top100_count" ARRAY(OBJECT(DYNAMIC) AS (
+                         "stmt" TEXT INDEX OFF STORAGE WITH (columnstore = false)
+                      )),
+                      "top100_duration_total" ARRAY(OBJECT(DYNAMIC) AS (
+                         "stmt" TEXT INDEX OFF STORAGE WITH (columnstore = false)
+                      )),
+                      "history" ARRAY(OBJECT(DYNAMIC) AS (
+                         "stmt" TEXT INDEX OFF STORAGE WITH (columnstore = false)
+                      ))
+                   )
+                )
+                """
+            else:
+                sql = f"""
                     CREATE TABLE IF NOT EXISTS {table}
                     (time TIMESTAMP DEFAULT NOW(), info OBJECT)
                 """
-                )
-            )
+
+            self.adapter.connection.execute(sa.text(sql))
             self.adapter.connection.execute(
                 sa.text(f"INSERT INTO {table} (info) VALUES (:info)"),  # noqa: S608
                 {"info": sample.to_dict()["data"]},


### PR DESCRIPTION
## Problem
```python
ProgrammingError: SQLParseException[Document contains at least one immense term in field="27" (whose UTF8 encoding is longer than the max length 32766), all of which were skipped.  Please correct the analyzer to not produce such terms.  The prefix of the first immense term is: '[83, 69, 76, 69, 67, 84, 32, 39, 123, 100, 97, 116, 101, 61, 50, 48, 50, 54, 45, 48, 53, 45, 49, 51, 84, 49, 51, 58, 50, 53]...', original message: bytes can be at most 32766 in length; got 49199]
```

## References
- GH-805