### PR TITLE
Fix `ctk info cluster` to report correct shard rebalancing progress

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   Thanks, @hammerhead.
 - Fixed `ctk cfr info record` re. `Document contains at least one immense term in field`.
   Thanks, @hammerhead.
+- Fixed `ctk info cluster` to report correct shard rebalancing progress.
+  Thanks, @hammerhead.
 
 ## 2026/05/12 v0.0.48
 - OCI: Installed `curl`, for Compose health checks

--- a/cratedb_toolkit/info/library.py
+++ b/cratedb_toolkit/info/library.py
@@ -504,6 +504,7 @@ class Library:
                     COUNT(*) AS count
                 FROM
                     sys.shards
+                WHERE recovery_stage != 'DONE'
                 GROUP BY table_name, schema_name, recovery_stage;
             """,
             description="Information about rebalancing progress.",


### PR DESCRIPTION
## Problem
On a fresh cluster, `ctk info cluster` reports a wrong shard rebalancing progress.

## Solution
> To be confirmed, but since we are interested in current rebalancings,
> `recovery_stage = 'DONE'` should be excluded from the query?

... added a constraint `WHERE recovery_stage != 'DONE'` to the relevant SQL statement.

## References
- GH-806
