### PR TITLE
Attempt to improve `ctk cfr sys-export` on very active/large clusters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   Thanks, @hammerhead.
 - Fixed `ctk info cluster` to report correct shard rebalancing progress.
   Thanks, @hammerhead.
+- Attempted to improve `ctk cfr sys-export` on very active/large clusters
+  by increasing `infer_schema_length` from 1_000 to 100_000. Thanks, @hammerhead.
 
 ## 2026/05/12 v0.0.48
 - OCI: Installed `curl`, for Compose health checks

--- a/cratedb_toolkit/cfr/systable.py
+++ b/cratedb_toolkit/cfr/systable.py
@@ -140,7 +140,7 @@ class SystemTableExporter(PathProvider):
         return pl.read_database(
             query=sql,  # noqa: S608
             connection=self.adapter.connection,
-            infer_schema_length=1000,
+            infer_schema_length=100_000,
         )
 
     def dump_table(self, frame: "pl.DataFrame", file: t.Union[t.TextIO, None] = None):


### PR DESCRIPTION
## Problem
```python
ERROR   : could not append value: "Cannot cast `'BA2'` of type `text`
to type `boolean`" of type: str to the builder; make sure that all rows
have the same schema or consider increasing `infer_schema_length`
```

## Attempt
Increase `infer_schema_length` from 1_000 to 100_000.

## References
- GH-807
