### PR TITLE
Stop leaking password to log output in `ctk cfr jobstats collect`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Stopped leaking password to log output in `ctk cfr jobstats collect`.
+  Thanks, @hammerhead.
 
 ## 2026/05/12 v0.0.48
 - OCI: Installed `curl`, for Compose health checks

--- a/cratedb_toolkit/cfr/jobstats.py
+++ b/cratedb_toolkit/cfr/jobstats.py
@@ -87,7 +87,7 @@ def boot(
     last_exec_table = os.getenv("LAST_EXEC_TABLE", f'"{schema}".jobstats_last')
 
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    logger.info(f"Connecting to {address.httpuri}")
+    logger.info(f"Connecting to {address.safe}")
     conn = client.connect(
         address.httpuri,
         username=address.username,


### PR DESCRIPTION
## Problem
`ctk cfr jobstats collect` leaked the raw password to its log output.

## References
- GH-808