### PR TITLE
Stop failing `ctk cfr jobstats ui` when job statistics recordings empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Stopped leaking password to log output in `ctk cfr jobstats collect`.
   Thanks, @hammerhead.
+- Stopped failing `ctk cfr jobstats ui` when job statistics recordings are empty.
+  Thanks, @hammerhead.
 
 ## 2026/05/12 v0.0.48
 - OCI: Installed `curl`, for Compose health checks

--- a/cratedb_toolkit/cfr/cli.py
+++ b/cratedb_toolkit/cfr/cli.py
@@ -196,6 +196,7 @@ def job_statistics_report(ctx: click.Context):
     import cratedb_toolkit.cfr.marimo
 
     address = DatabaseAddress.from_string(ctx.meta["cluster_url"])
+    probe_database_schema(address, schema_name="stats")
     os.environ["CRATEDB_CLUSTER_URL"] = address.dburi
     cratedb_toolkit.cfr.marimo.app.run()
 
@@ -213,6 +214,7 @@ def job_statistics_ui(ctx: click.Context):
     import cratedb_toolkit.cfr.marimo
 
     address = DatabaseAddress.from_string(ctx.meta["cluster_url"])
+    probe_database_schema(address, schema_name="stats")
     os.environ["CRATEDB_CLUSTER_URL"] = address.dburi
     server = marimo.create_asgi_app()
     server = server.with_app(path="/", root=cratedb_toolkit.cfr.marimo.__file__)
@@ -245,6 +247,18 @@ def record(ctx: click.Context, once: bool):
         recorder.record_once()
     else:
         recorder.record_forever()
+
+
+def probe_database_schema(address: DatabaseAddress, schema_name: str):
+    import sqlalchemy as sa
+
+    adapter = DatabaseAdapter(dburi=address.dburi, echo=False)
+    inspector = sa.inspect(adapter.engine)
+    if not inspector.has_schema(schema_name):
+        raise FileNotFoundError(
+            f"Schema `{schema_name}` missing. No job statistics recorded. "
+            "Please collect statistics using `ctk cfr jobstats collect` first."
+        )
 
 
 if getattr(sys, "frozen", False):

--- a/doc/cfr/jobstats.md
+++ b/doc/cfr/jobstats.md
@@ -11,3 +11,6 @@ ctk cfr jobstats view
 ctk cfr jobstats report
 ctk cfr jobstats ui
 ```
+
+Note: Please collect statistics first using `ctk cfr jobstats collect`,
+then use the other commands to display or explore them.


### PR DESCRIPTION
## Problem
`ctk cfr jobstats ui` fails with `SchemaUnknownException` when no statistics have been recorded yet.

## Solution
Improve error handling and documentation.
