### PR TITLE
Dependencies: Improved resolution of `pyorc` on Python 3.9 and earlier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ optional-dependencies.mongodb = [
   "cratedb-toolkit[io,io-recipe]",
   "orjson>=3.3.1,<4",
   "pymongo>=3.10.1,<4.17",
+  "pyorc<0.11; python_version<'3.10'",
   "python-bsonjs<0.8",
   "rich>=3.3.2,<16",
   "undatum<1.2",


### PR DESCRIPTION
## About
A little bit of dependency improvements for the `pyorc` package.

## References
- https://github.com/noirello/pyorc/issues/68