### PR TITLE
Fix invalid recovery stage column name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Fixed a failing SQL statement during `ctk info cluster`
 
-## 2026/06/17 v0.0.49 
+## 2026/06/17 v0.0.49
 - Stopped leaking password to log output in `ctk cfr jobstats collect`.
   Thanks, @hammerhead.
 - Stopped failing `ctk cfr jobstats ui` when job statistics recordings are empty.

--- a/cratedb_toolkit/info/library.py
+++ b/cratedb_toolkit/info/library.py
@@ -504,7 +504,7 @@ class Library:
                     COUNT(*) AS count
                 FROM
                     sys.shards
-                WHERE recovery_stage != 'DONE'
+                WHERE recovery['stage'] != 'DONE'
                 GROUP BY table_name, schema_name, recovery_stage;
             """,
             description="Information about rebalancing progress.",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The SQL was failing, see #840 (aliases cannot be referred to in `WHERE` clauses).

Also see https://cratedb.com/docs/crate/reference/en/latest/admin/system-information.html#shards for reference regarding column naming.

Fixes #840

## Checklist

 - [X] Link to issue this PR refers to (if applicable): Fixes #???
