### PR TITLE
Harmonize drivers to `crate<2.2` and `sqlalchemy-cratedb<0.43`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,12 +242,14 @@ optional-dependencies.nlsql = [
   "llama-index-llms-openrouter<0.6; python_version>='3.10'",
 ]
 optional-dependencies.pymongo = [
+  "crate<2.2",
   "jessiql==1.0.0rc1",
   "numpy<2",
   "pandas<2.2",
   "pymongo<4.9",
   "setuptools<81",
   "sqlalchemy<2",
+  "sqlalchemy-cratedb<0.43",
 ]
 optional-dependencies.release = [
   "build<2",


### PR DESCRIPTION
## Problem
One nightly scheduled CI run started failing. A subsystem that still uses SQLAlchemy 1.4 raised this error.
```
crate.client.exceptions.ProgrammingError:
SQLParseException[line 1:49: no viable alternative at input 'VALUES (%']
```

## Solution
Use previous driver tandem.

## References
- https://github.com/crate/crate-python/issues/815
- https://github.com/crate/sqlalchemy-cratedb/issues/273#issuecomment-4745346333

/cc @bgunebakan, @kneth 