### PR TITLE
I/O: Migrate from `undatum` to `iterabledata`

### DIFF
--- a/cratedb_toolkit/io/mongodb/adapter.py
+++ b/cratedb_toolkit/io/mongodb/adapter.py
@@ -17,7 +17,7 @@ import yarl
 from attrs import define, field
 from boltons.urlutils import URL
 from bson.raw_bson import RawBSONDocument
-from undatum.common.iterable import IterableData
+from iterable.helpers.detect import open_iterable
 
 from cratedb_toolkit.io.mongodb.model import DocumentDict
 from cratedb_toolkit.io.mongodb.util import batches
@@ -138,7 +138,7 @@ class MongoDBFilesystemAdapter(MongoDBAdapterBase):
         if self._path.suffix in [".json", ".jsonl", ".ndjson"]:
             data = read_json(str(self._path))
         elif ".bson" in str(self._path):
-            data = IterableData(str(self._path), options={"format_in": "bson"}).iter()
+            data = open_iterable(str(self._path))
         else:
             raise ValueError(f"Unsupported file type: {self._path.suffix}")
         return batches(data, self.batch_size)

--- a/cratedb_toolkit/io/mongodb/util.py
+++ b/cratedb_toolkit/io/mongodb/util.py
@@ -2,6 +2,7 @@ import re
 import typing as t
 
 from commons_codec.transform.mongodb import Document
+from iterable.base import BaseIterable
 from pymongo.cursor import Cursor
 
 from cratedb_toolkit.io.mongodb.model import DocumentDict, Documents
@@ -46,7 +47,7 @@ def sanitize_field_names(data: DocumentDict) -> DocumentDict:
 
 
 def batches(
-    data: t.Union[Cursor, Documents, t.Generator[Document, None, None]], batch_size: int = 100
+    data: t.Union[BaseIterable, Cursor, Documents, t.Generator[Document, None, None]], batch_size: int = 100
 ) -> t.Generator[Documents, None, None]:
     """
     Generate batches of documents.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,11 +208,11 @@ optional-dependencies.mcp = [
 optional-dependencies.mongodb = [
   "commons-codec[mongodb]>=0.0.22",
   "cratedb-toolkit[io,io-recipe]",
+  "iterabledata[bson]<2",
   "orjson>=3.3.1,<4",
   "pymongo>=3.10.1,<4.17",
   "python-bsonjs<0.8",
   "rich>=3.3.2,<16",
-  "undatum<1.2",
 ]
 optional-dependencies.nlsql = [
   "llama-index-llms-anthropic<0.12",
@@ -353,6 +353,7 @@ analysis.allowed-unresolved-imports = [
   "fastapi.**",
   "importlib_metadata.**",
   "importlib_resources.**",
+  "iterable.**",
   "jessiql.**",
   "kaggle.**",
   "kinesis.**",
@@ -362,7 +363,6 @@ analysis.allowed-unresolved-imports = [
   "pymongo.**",
   "sqlalchemy.**",
   "tikray.**",
-  "undatum.**",
 ]
 
 [tool.pytest]

--- a/tests/io/mongodb/conftest.py
+++ b/tests/io/mongodb/conftest.py
@@ -14,7 +14,7 @@ pytest.importorskip("bson", reason="Skipping tests because bson is not installed
 pytest.importorskip("bsonjs", reason="Skipping tests because bsonjs is not installed")
 pytest.importorskip("pymongo", reason="Skipping tests because pymongo is not installed")
 pytest.importorskip("rich", reason="Skipping tests because rich is not installed")
-pytest.importorskip("undatum", reason="Skipping tests because undatum is not installed")
+pytest.importorskip("iterable", reason="Skipping tests because iterabledata is not installed")
 
 
 # Define databases to be deleted before running each test case.


### PR DESCRIPTION
## About
@ivbeg told us that [iterabledata](https://pypi.org/project/iterabledata/) is all we need. Thank you.

## References
- Resolve GH-586

