### PR TITLE
Chore: Fix two software tests re. updated "Unauthorized" message

### DIFF
--- a/tests/cluster/test_cli.py
+++ b/tests/cluster/test_cli.py
@@ -114,4 +114,4 @@ def test_standalone_cluster_info_unknown(caplog):
     )
     assert result.exit_code == 1
     assert "Failed to inquire cluster info" in caplog.text
-    assert "401 - Unauthorized" in result.output
+    assert "{'error': {'reason': 'Unauthorized', 'message': 'Missing access_token'}, 'status': 401}" in result.output

--- a/tests/cluster/test_model.py
+++ b/tests/cluster/test_model.py
@@ -7,4 +7,4 @@ from cratedb_toolkit.exception import CroudException
 def test_cluster_info_managed_unauthorized():
     with pytest.raises(CroudException) as ex:
         ClusterInformation.from_id_or_name(cluster_id="foo", cluster_name="bar")
-    assert ex.match("401 - Unauthorized")
+    assert ex.match("{'error': {'reason': 'Unauthorized', 'message': 'Missing access_token'}, 'status': 401}")


### PR DESCRIPTION
## Problem
Two little test failures were discovered [here](https://github.com/crate/cratedb-toolkit/actions/runs/28158394399/job/83392486788#step:6:563). This patch fixes them by updating an error message that apparently changed.

## Trivia
Because of GH-863, I can't toggle this PR into review mode. @kneth and @bgunebakan: Please commandeer at your disposal, for example by cherry-picking the commit into a separate PR.
