### PR TITLE
Document what ctk info and ctk cfr subcommands actually return

### DIFF
--- a/doc/cfr/index.md
+++ b/doc/cfr/index.md
@@ -2,7 +2,13 @@
 # CrateDB Cluster Flight Recorder (CFR)
 
 CrateDB Toolkit provides a few utilities about diagnostics and metadata
-information collection and recording per `ctk cfr`. 
+information collection and recording per `ctk cfr`.
+
+The three areas differ in how raw vs. interpreted their output is:
+- `sys-export` / `sys-import` — a true raw copy of every `sys.*` table. See {ref}`cfr-systable`.
+- `jobstats collect` / `view` — raw, time-series query statistics, persisted to a schema.
+  `report` / `ui` additionally launch an interpreted. See {ref}`cfr-jobstats`.
+- `info record` — a raw snapshot of `ctk info cluster` and `ctk info jobs`. See {ref}`cfr-info`.
 
 ```{toctree}
 :maxdepth: 1

--- a/doc/cfr/info.md
+++ b/doc/cfr/info.md
@@ -1,10 +1,19 @@
 (cfr-info)=
 # Cluster information recorder
 
-Record complete outcomes of `ctk info cluster` and `ctk info jobs`.
+Record complete outcomes of `ctk info cluster` and `ctk info jobs`, the same raw/curated
+elements those commands return (see {ref}`cluster-info`), persisted as-is into the
+`ext.clusterinfo` and `ext.jobinfo` tables respectively, one row per snapshot.
 ```shell
 ctk cfr info record
 ```
+
+By default, a new snapshot is recorded every 10 seconds. Use `--once` to record a single
+snapshot and exit.
+```shell
+ctk cfr info record --once
+```
+
 :::{tip}
 See also {ref}`cluster-info`.
 :::

--- a/doc/cfr/jobstats.md
+++ b/doc/cfr/jobstats.md
@@ -1,7 +1,14 @@
 (cfr-jobstats)=
 # Job statistics collector
 
-Collect and display job statistics.
+Collect and display job statistics. This is a separate, continuously-collected time series
+of query statistics, distinct from the one-shot `ctk info jobs` snapshot. 
+See {ref}`cluster-info`.
+
+`collect` and `view` return raw, time-series JSON persisted to the `stats` schema. `report`
+and `ui` instead launch an interpreted, interactive dashboard on top of the same collected
+data.
+
 ```shell
 export CRATEDB_CLUSTER_URL=crate://crate@localhost:4200/?schema=stats
 ```
@@ -14,3 +21,17 @@ ctk cfr jobstats ui
 
 Note: Please collect statistics first using `ctk cfr jobstats collect`,
 then use the other commands to display or explore them.
+
+:::{rubric} Options
+:::
+`ctk cfr jobstats collect`:
+- `--once` — record only one sample, then exit, instead of collecting continuously
+- `--reportdb` / `-r` — a separate database URL to store report data in
+  (`crate://crate@localhost:4200/?sslmode=require`)
+- `--anonymize` — path to a decoder dictionary file for anonymizing SQL statements before
+  they're stored; using the flag without a value defaults to `decoder_dictionary.json`
+
+`ctk cfr jobstats view`:
+- `--reportdb` / `-r` — a separate database URL to read report data from
+- `--deanonymize` — path to the decoder dictionary file used to reverse `--anonymize`,
+  to view statements in their original form

--- a/doc/cfr/systable.md
+++ b/doc/cfr/systable.md
@@ -6,6 +6,9 @@ CFR's `sys-export` and `sys-import` commands support collecting and analyzing
 information about CrateDB clusters for support requests and self-service
 debugging.
 
+Output is a true raw copy of every `sys.*` table.
+See {ref}`cluster-info` for the curated alternatives.
+
 ## Install
 
 ```shell

--- a/doc/info/index.md
+++ b/doc/info/index.md
@@ -3,6 +3,18 @@
 
 A bundle of information inquiry utilities, for diagnostics and more.
 
+:::{tip}
+**Which command do I want?**
+- `ctk info cluster` / `ctk info jobs` — a curated, one-shot snapshot of hand-picked health,
+  shard, and query metrics. Good for a quick look at what's going on right now.
+- `ctk cfr info record` — the same snapshot, persisted over time. See {ref}`cfr-info`.
+- `ctk cfr jobstats collect` / `view` — a separate, continuously-collected time series of
+  query statistics, not the same data as `ctk info jobs`. See {ref}`cfr-jobstats`.
+- `ctk cfr sys-export` — a true raw dump of every system table, no interpretation. This is
+  the one to reach for when collecting diagnostics for a CrateDB support case.
+  See {ref}`cfr-systable`.
+:::
+
 ## Install
 ```shell
 pip install --upgrade 'cratedb-toolkit'
@@ -35,17 +47,66 @@ For some commands, both options might not be available yet, just one of them.
 
 
 ### One shot commands
-Display system and database cluster information.
+Display system and database cluster information. Output is mostly raw SQL result rows;
+a handful of elements (`cluster_name`, `cluster_nodes_count`, `max_checkpoint_delta`,
+`shard_not_started_count`, `shard_total_count`, `translog_uncommitted_size`) are reduced
+to a single value.
 ```shell
 ctk info cluster
 ```
 
-Display database cluster job information.
+:::{rubric} Elements
+:::
+Health:
+- **Cluster name** — the cluster's name
+- **Cluster Health** — overall cluster health, including missing and underreplicated shard counts
+- **Total number of cluster nodes** — node count
+- **Cluster Nodes** — telemetry information for all cluster nodes
+- **Table Health** — table health short summary
+- **Recent Backups** — most recent 10 backups
+
+Shards:
+- **Shard Allocation** — support identifying issues with shard allocation
+- **Table Allocations** — table allocation across nodes, shards, and partitions
+- **Shard Distribution** — shard distribution across nodes
+- **Table Shard Count** — total number of shards per table
+- **Shard Rebalancing Progress** — information about rebalancing progress
+- **Shard Rebalancing Status** — information about rebalancing activities
+- **Shards not started** — information about shards which have not been started
+- **Number of shards not started** — total number of shards which have not been started
+- **Delta between local and global checkpoint** — a significantly large delta can mean shard
+  replication has stalled or slowed down
+- **Number of shards** — total number of shards
+- **Uncommitted Translog** — compares `flush_threshold_size` with the `uncommitted_size` of a
+  shard, to check translogs are being committed properly
+- **Total uncommitted translog size** — a large uncommitted total can indicate issues with
+  shard replication
+
+Display database cluster job information: a one-shot, ad hoc snapshot, not persisted over
+time. Contrast with `ctk cfr jobstats collect`, which collects the same kind of information
+continuously, see {ref}`cfr-jobstats`.
 ```shell
 ctk info jobs
 ```
 
-Display database cluster log messages.
+:::{rubric} Elements
+:::
+- **Query age range** — timestamps of first and last job
+- **Queries by user** — total number of queries per user
+- **Query Duration Distribution (Buckets)** — distribution of query durations, bucketed
+- **Query Duration Distribution (Percentiles)** — distribution of query durations, percentiles
+- **Query History** — statements and durations of the 100 most recent queries / jobs
+- **Query History Count** — total number of queries on this node
+- **Query performance 15min** — query performance within the last 15 minutes: queries per
+  second, and query speed (ms)
+- **Currently Running Queries** — statements and durations of currently running queries / jobs
+- **Number of running queries** — total number of currently running queries
+- **Query frequency** — the 100 most frequent queries
+- **Individual Query Duration** — the 100 queries by individual duration (ms)
+- **Total Query Duration** — the 100 queries by total duration (ms)
+
+Display database cluster log messages: a raw, limited passthrough of the most recent
+`sys.jobs_log` rows, filtered to exclude queries against `sys.*`/`information_schema.*`.
 ```shell
 ctk info logs
 ```
@@ -65,7 +126,9 @@ Install.
 pip install --upgrade 'cratedb-toolkit[service]'
 ```
 
-Expose collected status information.
+Expose collected status information. An HTTP wrapper around the same data as
+`ctk info cluster`, the only endpoint is `GET /info/all`.
+
 ```shell
 ctk info serve
 ```


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Documentation-only change addressing #869 (follow-up to the scope discussion in #855). This PR expands the existing doc pages so that, for every subcommand.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #869
