### PR TITLE
Revert "Bump python from 3.13-slim-bookworm to 3.14-slim-bookworm in /release/oci-full"

### DIFF
--- a/release/oci-full/Dockerfile
+++ b/release/oci-full/Dockerfile
@@ -5,7 +5,7 @@
 # - https://github.com/FernandoMiguel/Buildkit#mounttypecache
 
 # Stage 1: Build wheel package
-FROM python:3.14-slim-bookworm AS build
+FROM python:3.13-slim-bookworm AS build
 
 # Configure operating system.
 ENV DEBIAN_FRONTEND=noninteractive
@@ -35,7 +35,7 @@ RUN pip install build
 RUN python -m build --wheel ${BUILD}
 
 
-FROM python:3.14-slim-bookworm AS package
+FROM python:3.13-slim-bookworm AS package
 
 LABEL org.opencontainers.image.source="https://github.com/crate/cratedb-toolkit" \
       org.opencontainers.image.title="cratedb-toolkit (full)" \


### PR DESCRIPTION
Reverts crate/cratedb-toolkit#557

**pyiceberg (a cratedb-toolkit[full] dependency)** ships no `cp314` wheel yet, so uv falls back to compiling it from source and fails with error: `command 'gcc' failed: No such file or directory` in the slim image.

apache/iceberg-python#3299 ("Adds prebuilt support for python 3.14") merged into main, but no released pyiceberg has cp314 wheels yet. The latest on PyPI is 0.11.1. Every published version (0.10.0 → 0.11.1) ships cp313 wheels but zero cp314 wheels.