### PR TITLE
Improve ctk cfr sys-export command and docs

### DIFF
--- a/cratedb_toolkit/cfr/cli.py
+++ b/cratedb_toolkit/cfr/cli.py
@@ -30,6 +30,13 @@ def sys_export(ctx: click.Context, target: str):
     Export CrateDB system tables.
     """
     cluster_url = ctx.meta["cluster_url"]
+
+    if ctx.meta.get("scrub", False):
+        logger.warning(
+            "`--scrub` has no effect on `sys-export`: it blanks out information about the "
+            "local machine environment, not data collected from the cluster."
+        )
+
     try:
         target_path = path_from_url(target)
         stc = SystemTableExporter(dburi=cluster_url, target=target_path)
@@ -41,7 +48,7 @@ def sys_export(ctx: click.Context, target: str):
         path = stc.save()
 
         if archive is not None:
-            path = archive.make_tarfile()
+            path = archive.make_tarfile(source_path=path, arcname=f"{stc.info.cluster_name}-{path.name}")
             archive.close()
             logger.info(f"Created archive file {target}")
 

--- a/cratedb_toolkit/cfr/systable.py
+++ b/cratedb_toolkit/cfr/systable.py
@@ -396,6 +396,12 @@ class SystemTableExporter(PathProvider):
         path_table_data = path_data / f"{tablename_out}.{self.data_format}"
         self.table_count += 1
 
+        skip_reason = SystemTableKnowledge.DATA_SKIPLIST.get((schema, tablename))
+        if skip_reason is not None:
+            logger.debug(f"Not collecting {schema}.{tablename}: {skip_reason}")
+            self.data_skipped.append({"schema": schema, "table": tablename, "reason": skip_reason})
+            return
+
         # Schema. Not every CrateDB column type can be represented in SQLAlchemy
         # DDL, so reflection can fail per table.
         try:
@@ -405,12 +411,6 @@ class SystemTableExporter(PathProvider):
         except Exception as ex:
             logger.warning(f"Could not generate schema for {schema}.{tablename}: {ex}")
             self.schema_failures.append({"schema": schema, "table": tablename, "reason": f"{type(ex).__name__}: {ex}"})
-
-        skip_reason = SystemTableKnowledge.DATA_SKIPLIST.get((schema, tablename))
-        if skip_reason is not None:
-            logger.debug(f"Not collecting data of {schema}.{tablename}: {skip_reason}")
-            self.data_skipped.append({"schema": schema, "table": tablename, "reason": skip_reason})
-            return
 
         try:
             frame = self.redact(self.read_table(tablename=tablename, schema=schema), schema, tablename)

--- a/cratedb_toolkit/cfr/systable.py
+++ b/cratedb_toolkit/cfr/systable.py
@@ -65,6 +65,22 @@ class SystemTableKnowledge:
     # `SHOW CREATE TABLE` only works on those, not on views or system relations.
     BASE_TABLE_TYPE = "BASE TABLE"
 
+    # Columns CrateDB hands out in the clear that must never reach a bundle.
+    REDACTED_COLUMNS: t.Dict[t.Tuple[str, str], t.Tuple[str, ...]] = {
+        (INFORMATION_SCHEMA, "user_mapping_options"): ("option_value",),
+        (INFORMATION_SCHEMA, "foreign_server_options"): ("option_value",),
+    }
+
+    # What a redacted value is replaced with.
+    REDACTION_MARKER = "[redacted by cratedb-toolkit]"
+
+    # Tables whose data is deliberately not collected
+    DATA_SKIPLIST: t.Dict[t.Tuple[str, str], str] = {
+        (SYS_SCHEMA, "summits"): (
+            "static dataset shipped with the server"
+        ),
+    }
+
 
 class ExportSettings:
     """
@@ -222,6 +238,8 @@ class SystemTableExporter(PathProvider):
         self.schema_capture = SchemaCapture(adapter=self.adapter)
         self.schema_failures: t.List[t.Dict[str, str]] = []
         self.data_failures: t.List[t.Dict[str, str]] = []
+        self.definition_failures: t.List[t.Dict[str, str]] = []
+        self.data_skipped: t.List[t.Dict[str, str]] = []
         self.table_count = 0
         self.data_file_count = 0
 
@@ -249,6 +267,24 @@ class SystemTableExporter(PathProvider):
             infer_schema_length=100_000,
         )
 
+    def redact(self, frame: "pl.DataFrame", schema: str, tablename: str) -> "pl.DataFrame":
+        """
+        Blank out values CrateDB returns in the clear, but a bundle must not carry.
+
+        """
+        import polars as pl
+
+        columns = SystemTableKnowledge.REDACTED_COLUMNS.get((schema, tablename))
+        if not columns:
+            return frame
+        marker = SystemTableKnowledge.REDACTION_MARKER
+        replacements = [
+            pl.when(pl.col(column).is_null()).then(None).otherwise(pl.lit(marker)).alias(column)
+            for column in columns
+            if column in frame.columns
+        ]
+        return frame.with_columns(replacements) if replacements else frame
+
     def dump_table(self, frame: "pl.DataFrame", file: t.Union[t.TextIO, None] = None):
         if self.data_format == "csv":
             # polars.exceptions.ComputeError: CSV format does not support nested data
@@ -265,7 +301,8 @@ class SystemTableExporter(PathProvider):
         import cratedb_toolkit
 
         self.path.mkdir(exist_ok=True, parents=True)
-        timestamp = dt.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+        now = dt.datetime.now().astimezone()
+        timestamp = now.strftime("%Y-%m-%dT%H-%M-%S")
         # The bundle root. `sys-import` consumes the per-schema subdirectories
         bundle_path = self.path / self.info.cluster_name / timestamp
         logger.info(f"Exporting system tables to: {bundle_path}")
@@ -278,15 +315,16 @@ class SystemTableExporter(PathProvider):
                 bundle_path,
                 cratedb_version=self.cratedb_version(),
                 toolkit_version=cratedb_toolkit.__version__,
-                timestamp=timestamp,
+                collected_at=now.isoformat(timespec="seconds"),
                 definitions=definitions,
             )
 
         schemas = ", ".join(SystemTableKnowledge.EXPORT_SCHEMAS)
         logger.info(
             f"Successfully exported {self.table_count} tables from {schemas} "
-            f"({self.data_file_count} with data, "
-            f"{len(self.schema_failures)} schema and {len(self.data_failures)} data failures)"
+            f"({self.data_file_count} with data, {len(self.data_skipped)} skipped, "
+            f"{len(self.schema_failures)} schema and {len(self.data_failures)} data failures, "
+            f"{len(self.definition_failures)} definition failures)"
         )
         return bundle_path
 
@@ -295,7 +333,7 @@ class SystemTableExporter(PathProvider):
         bundle_path: Path,
         cratedb_version: str,
         toolkit_version: str,
-        timestamp: str,
+        collected_at: str,
         definitions: t.Dict[str, int],
     ) -> Path:
         """
@@ -305,13 +343,19 @@ class SystemTableExporter(PathProvider):
             "cluster_name": self.info.cluster_name,
             "cratedb_version": cratedb_version,
             "toolkit_version": toolkit_version,
-            "collected_at": timestamp,
+            "collected_at": collected_at,
             "schemas_exported": list(SystemTableKnowledge.EXPORT_SCHEMAS),
             "tables_exported": self.table_count,
             "data_files_written": self.data_file_count,
             "definitions_captured": definitions,
             "schema_failures": self.schema_failures,
             "data_failures": self.data_failures,
+            "definition_failures": self.definition_failures,
+            "data_skipped": self.data_skipped,
+            "redactions": [
+                {"schema": schema, "table": table, "columns": list(columns)}
+                for (schema, table), columns in SystemTableKnowledge.REDACTED_COLUMNS.items()
+            ],
         }
         target = bundle_path / ExportSettings.MANIFEST_FILENAME
         target.write_text(json.dumps(manifest, indent=2) + "\n")
@@ -364,8 +408,14 @@ class SystemTableExporter(PathProvider):
             logger.warning(f"Could not generate schema for {schema}.{tablename}: {ex}")
             self.schema_failures.append({"schema": schema, "table": tablename, "reason": f"{type(ex).__name__}: {ex}"})
 
+        skip_reason = SystemTableKnowledge.DATA_SKIPLIST.get((schema, tablename))
+        if skip_reason is not None:
+            logger.debug(f"Not collecting data of {schema}.{tablename}: {skip_reason}")
+            self.data_skipped.append({"schema": schema, "table": tablename, "reason": skip_reason})
+            return
+
         try:
-            frame = self.read_table(tablename=tablename, schema=schema)
+            frame = self.redact(self.read_table(tablename=tablename, schema=schema), schema, tablename)
             if frame.is_empty():
                 return
             mode = "wb" if self.data_format in ["parquet", "pq"] else "w"
@@ -390,6 +440,7 @@ class SystemTableExporter(PathProvider):
             relations = self.schema_capture.relations()
         except Exception as ex:
             logger.warning(f"Could not discover user relations: {ex}")
+            self.definition_failures.append({"kind": "relations", "reason": f"{type(ex).__name__}: {ex}"})
             return counts
 
         for relation in tqdm(relations, desc="Capturing definitions", disable=None):
@@ -405,11 +456,15 @@ class SystemTableExporter(PathProvider):
                 counts["tables"] += 1
             except Exception as ex:
                 logger.warning(f"Could not capture definition of {schema}.{name}: {ex}")
+                self.definition_failures.append(
+                    {"kind": "table", "schema": schema, "name": name, "reason": f"{type(ex).__name__}: {ex}"}
+                )
 
         try:
             views = self.schema_capture.views()
         except Exception as ex:
             logger.warning(f"Could not read view definitions: {ex}")
+            self.definition_failures.append({"kind": "views", "reason": f"{type(ex).__name__}: {ex}"})
             return counts
 
         for view in views:
@@ -419,10 +474,15 @@ class SystemTableExporter(PathProvider):
             if not definition:
                 continue
             try:
-                (path_views / f"{schema}.{name}.sql").write_text(definition.rstrip() + "\n")
+                relation = self.adapter.quote_relation_name(f"{schema}.{name}")
+                statement = f"CREATE OR REPLACE VIEW {relation} AS\n{definition.rstrip()};\n"
+                (path_views / f"{schema}.{name}.sql").write_text(statement)
                 counts["views"] += 1
             except Exception as ex:
                 logger.warning(f"Could not capture view {schema}.{name}: {ex}")
+                self.definition_failures.append(
+                    {"kind": "view", "schema": schema, "name": name, "reason": f"{type(ex).__name__}: {ex}"}
+                )
 
         return counts
 

--- a/cratedb_toolkit/cfr/systable.py
+++ b/cratedb_toolkit/cfr/systable.py
@@ -16,6 +16,7 @@ https://docs.sqlalchemy.org/en/20/faq/metadata_schema.html#how-can-i-get-the-cre
 """
 
 import datetime as dt
+import json
 import logging
 import os
 import tarfile
@@ -51,9 +52,18 @@ class SystemTableKnowledge:
     # Name of CrateDB's schema for system tables.
     SYS_SCHEMA = "sys"
 
-    # TODO: Reflecting the `summits` table raises an error.
-    # AttributeError: 'UserDefinedType' object has no attribute 'get_col_spec'
-    REFLECTION_BLOCKLIST = ["summits"]
+    # Name of the SQL standard schema describing the cluster's own relations.
+    INFORMATION_SCHEMA = "information_schema"
+
+    # Schemas exported verbatim into the bundle, in bundle order.
+    EXPORT_SCHEMAS = (SYS_SCHEMA, INFORMATION_SCHEMA)
+
+    # Schemas that do not belong to the user, hence are not subject to DDL capture.
+    NON_USER_SCHEMAS = (SYS_SCHEMA, INFORMATION_SCHEMA, "pg_catalog", "blob")
+
+    # `information_schema.tables.table_type` value identifying a regular table.
+    # `SHOW CREATE TABLE` only works on those, not on views or system relations.
+    BASE_TABLE_TYPE = "BASE TABLE"
 
 
 class ExportSettings:
@@ -68,6 +78,20 @@ class ExportSettings:
     # The filename prefix when storing tables to disk.
     TABLE_FILENAME_PREFIX = "sys-"
 
+    # Per-schema filename prefixes. `sys` keeps its historical prefix.
+    FILENAME_PREFIXES = {
+        SystemTableKnowledge.SYS_SCHEMA: TABLE_FILENAME_PREFIX,
+        SystemTableKnowledge.INFORMATION_SCHEMA: "is-",
+    }
+
+    # Where the user's own relation definitions are stored.
+    DDL_PATH = "ddl"
+    DDL_TABLES_PATH = "tables"
+    DDL_VIEWS_PATH = "views"
+
+    # The bundle's self-description.
+    MANIFEST_FILENAME = "manifest.json"
+
 
 class SystemTableInspector:
     """
@@ -80,13 +104,18 @@ class SystemTableInspector:
         self.engine = self.adapter.engine
         self.inspector = sa.inspect(self.engine)
 
-    def table_names(self):
-        return self.inspector.get_table_names(schema=SystemTableKnowledge.SYS_SCHEMA)
+    def table_names(self, schema: t.Optional[str] = None):
+        return self.inspector.get_table_names(schema=schema or SystemTableKnowledge.SYS_SCHEMA)
 
     def ddl(
-        self, tablename_in: str, tablename_out: str, out_schema: t.Optional[str] = None, with_drop_table: bool = False
+        self,
+        tablename_in: str,
+        tablename_out: str,
+        in_schema: t.Optional[str] = None,
+        out_schema: t.Optional[str] = None,
+        with_drop_table: bool = False,
     ) -> str:
-        meta = sa.MetaData(schema=SystemTableKnowledge.SYS_SCHEMA)
+        meta = sa.MetaData(schema=in_schema or SystemTableKnowledge.SYS_SCHEMA)
         table = sa.Table(tablename_in, meta, autoload_with=self.engine)
         table.schema = out_schema
         table.name = tablename_out
@@ -95,6 +124,57 @@ class SystemTableInspector:
             sql += sa.schema.DropTable(table, if_exists=True).compile(self.engine).string.strip() + ";\n"
         sql += sa.schema.CreateTable(table, if_not_exists=True).compile(self.engine).string.strip() + ";\n"
         return sql
+
+
+class SchemaCapture:
+    """
+    Capture the user's own relation definitions.
+
+    Table definitions come from the cluster's own `SHOW CREATE TABLE`, rather
+    than being derived by hand from metadata tables: that renders every clause
+    support needs (nested objects, arrays, geo and vector types, generated
+    columns, fulltext indexes, sharding, partitioning, table settings).
+
+    """
+
+    NON_USER_SCHEMAS_SQL = ", ".join(f"'{name}'" for name in SystemTableKnowledge.NON_USER_SCHEMAS)
+
+    def __init__(self, adapter: DatabaseAdapter):
+        self.adapter = adapter
+
+    def relations(self) -> t.List[t.Dict[str, str]]:
+        """
+        Discover the user's relations, i.e. everything outside the system schemas.
+        """
+        sql = f"""
+            SELECT table_schema, table_name, table_type
+            FROM information_schema.tables
+            WHERE table_schema NOT IN ({self.NON_USER_SCHEMAS_SQL})
+            ORDER BY table_schema, table_name
+        """  # noqa: S608
+        return self.adapter.run_sql(sql, records=True) or []
+
+    def table_ddl(self, schema: str, table: str) -> str:
+        """
+        Ask the cluster for a table's own definition.
+        """
+        relation = self.adapter.quote_relation_name(f"{schema}.{table}")
+        records = self.adapter.run_sql(f"SHOW CREATE TABLE {relation}", records=True)
+        if not records:
+            raise ValueError(f"No definition returned for {schema}.{table}")
+        return str(list(records[0].values())[0])
+
+    def views(self) -> t.List[t.Dict[str, str]]:
+        """
+        Read view definitions, which `SHOW CREATE TABLE` cannot provide.
+        """
+        sql = f"""
+            SELECT table_schema, table_name, view_definition
+            FROM information_schema.views
+            WHERE table_schema NOT IN ({self.NON_USER_SCHEMAS_SQL})
+            ORDER BY table_schema, table_name
+        """  # noqa: S608
+        return self.adapter.run_sql(sql, records=True) or []
 
 
 class PathProvider:
@@ -112,10 +192,13 @@ class Archive:
     def close(self):
         self.temp_dir.cleanup()
 
-    def make_tarfile(self) -> Path:
-        source_path = self.path_provider.path
+    def make_tarfile(self, source_path: t.Optional[Path] = None, arcname: t.Optional[str] = None) -> Path:
+        """
+        Archive `source_path` under a single top-level entry named `arcname`.
+        """
+        source_path = source_path or self.path_provider.path
         with tarfile.open(self.target_path, "x:gz") as tar:
-            tar.add(source_path.absolute(), arcname=os.path.basename(source_path))
+            tar.add(source_path.absolute(), arcname=arcname or os.path.basename(source_path))
         return self.target_path
 
 
@@ -124,18 +207,41 @@ class SystemTableExporter(PathProvider):
     Export schema and data from CrateDB system tables.
     """
 
-    def __init__(self, dburi: str, target: t.Union[Path], data_format: DataFormat = "jsonl"):
+    def __init__(
+        self,
+        dburi: str,
+        target: t.Union[Path],
+        data_format: DataFormat = "jsonl",
+    ):
         super().__init__(target)
         self.dburi = dburi
         self.data_format = data_format
         self.adapter = DatabaseAdapter(dburi=self.dburi)
         self.info = InfoContainer(adapter=self.adapter)
         self.inspector = SystemTableInspector(dburi=self.dburi)
+        self.schema_capture = SchemaCapture(adapter=self.adapter)
+        self.schema_failures: t.List[t.Dict[str, str]] = []
+        self.data_failures: t.List[t.Dict[str, str]] = []
+        self.table_count = 0
+        self.data_file_count = 0
 
-    def read_table(self, tablename: str) -> "pl.DataFrame":
+    def cratedb_version(self) -> str:
+        """
+        Read the cluster's version from the cluster. Never assume it.
+        """
+        try:
+            records = self.adapter.run_sql("SELECT version['number'] AS version FROM sys.nodes LIMIT 1", records=True)
+            if records:
+                return str(list(records[0].values())[0])
+        except Exception as ex:
+            logger.warning(f"Could not determine CrateDB version: {ex}")
+        return "unknown"
+
+    def read_table(self, tablename: str, schema: t.Optional[str] = None) -> "pl.DataFrame":
         import polars as pl
 
-        sql = f'SELECT * FROM "{SystemTableKnowledge.SYS_SCHEMA}"."{tablename}"'  # noqa: S608
+        schema = schema or SystemTableKnowledge.SYS_SCHEMA
+        sql = f'SELECT * FROM "{schema}"."{tablename}"'  # noqa: S608
         logger.debug(f"Running SQL: {sql}")
         return pl.read_database(
             query=sql,  # noqa: S608
@@ -156,48 +262,169 @@ class SystemTableExporter(PathProvider):
             raise NotImplementedError(f"Output format not implemented: {self.data_format}")
 
     def save(self) -> Path:
+        import cratedb_toolkit
+
         self.path.mkdir(exist_ok=True, parents=True)
         timestamp = dt.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
-        path = self.path / self.info.cluster_name / timestamp / "sys"
-        logger.info(f"Exporting system tables to: {path}")
-        path_schema = path / ExportSettings.SCHEMA_PATH
-        path_data = path / ExportSettings.DATA_PATH
+        # The bundle root. `sys-import` consumes the per-schema subdirectories
+        bundle_path = self.path / self.info.cluster_name / timestamp
+        logger.info(f"Exporting system tables to: {bundle_path}")
+
+        with logging_redirect_tqdm():
+            for schema in SystemTableKnowledge.EXPORT_SCHEMAS:
+                self._save_schema(bundle_path, schema)
+            definitions = self._save_definitions(bundle_path)
+            self._write_manifest(
+                bundle_path,
+                cratedb_version=self.cratedb_version(),
+                toolkit_version=cratedb_toolkit.__version__,
+                timestamp=timestamp,
+                definitions=definitions,
+            )
+
+        schemas = ", ".join(SystemTableKnowledge.EXPORT_SCHEMAS)
+        logger.info(
+            f"Successfully exported {self.table_count} tables from {schemas} "
+            f"({self.data_file_count} with data, "
+            f"{len(self.schema_failures)} schema and {len(self.data_failures)} data failures)"
+        )
+        return bundle_path
+
+    def _write_manifest(
+        self,
+        bundle_path: Path,
+        cratedb_version: str,
+        toolkit_version: str,
+        timestamp: str,
+        definitions: t.Dict[str, int],
+    ) -> Path:
+        """
+        Describe the bundle, so a recipient knows what they are looking at.
+        """
+        manifest = {
+            "cluster_name": self.info.cluster_name,
+            "cratedb_version": cratedb_version,
+            "toolkit_version": toolkit_version,
+            "collected_at": timestamp,
+            "schemas_exported": list(SystemTableKnowledge.EXPORT_SCHEMAS),
+            "tables_exported": self.table_count,
+            "data_files_written": self.data_file_count,
+            "definitions_captured": definitions,
+            "schema_failures": self.schema_failures,
+            "data_failures": self.data_failures,
+        }
+        target = bundle_path / ExportSettings.MANIFEST_FILENAME
+        target.write_text(json.dumps(manifest, indent=2) + "\n")
+        return target
+
+    def _save_schema(self, bundle_path: Path, schema: str) -> None:
+        """
+        Export every table of one schema.
+        """
+        base = bundle_path / schema
+        path_schema = base / ExportSettings.SCHEMA_PATH
+        path_data = base / ExportSettings.DATA_PATH
         path_schema.mkdir(parents=True, exist_ok=True)
         path_data.mkdir(parents=True, exist_ok=True)
-        with logging_redirect_tqdm():
-            self._save(path_schema, path_data)
-            return path
+        prefix = ExportSettings.FILENAME_PREFIXES[schema]
 
-    def _save(self, path_schema: Path, path_data: Path) -> None:
-        system_tables = self.inspector.table_names()
-        table_count = 0
-        for tablename in tqdm(system_tables, disable=None):
-            logger.debug(f"Exporting table: {tablename}")
-            if tablename in SystemTableKnowledge.REFLECTION_BLOCKLIST:
-                continue
+        try:
+            tablenames = self.inspector.table_names(schema=schema)
+        except Exception as ex:
+            logger.warning(f"Could not list tables of schema `{schema}`: {ex}")
+            self.data_failures.append({"schema": schema, "table": "*", "reason": f"{type(ex).__name__}: {ex}"})
+            return
 
-            path_table_schema = path_schema / f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}.sql"
-            path_table_data = path_data / f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}.{self.data_format}"
-            tablename_out = f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}"
+        for tablename in tqdm(tablenames, desc=f"Exporting {schema}", disable=None):
+            logger.debug(f"Exporting table: {schema}.{tablename}")
+            self._save_table(
+                schema=schema,
+                tablename=tablename,
+                path_schema=path_schema,
+                path_data=path_data,
+                prefix=prefix,
+            )
 
-            # Write the schema file.
+    def _save_table(self, schema: str, tablename: str, path_schema: Path, path_data: Path, prefix: str) -> None:
+        """
+        Export one table's schema and data *independently*.
+        """
+        tablename_out = f"{prefix}{tablename}"
+        path_table_schema = path_schema / f"{tablename_out}.sql"
+        path_table_data = path_data / f"{tablename_out}.{self.data_format}"
+        self.table_count += 1
+
+        # Schema. Not every CrateDB column type can be represented in SQLAlchemy
+        # DDL, so reflection can fail per table.
+        try:
+            ddl = self.inspector.ddl(tablename_in=tablename, tablename_out=tablename_out, in_schema=schema)
             with open(path_table_schema, "w") as fh_schema:
-                print(self.inspector.ddl(tablename_in=tablename, tablename_out=tablename_out), file=fh_schema)
+                print(ddl, file=fh_schema)
+        except Exception as ex:
+            logger.warning(f"Could not generate schema for {schema}.{tablename}: {ex}")
+            self.schema_failures.append({"schema": schema, "table": tablename, "reason": f"{type(ex).__name__}: {ex}"})
 
-            # Write the data file.
-            df = self.read_table(tablename=tablename)
-            if df.is_empty():
-                continue
-
-            table_count += 1
-
-            mode = "w"
-            if self.data_format in ["parquet", "pq"]:
-                mode = "wb"
+        try:
+            frame = self.read_table(tablename=tablename, schema=schema)
+            if frame.is_empty():
+                return
+            mode = "wb" if self.data_format in ["parquet", "pq"] else "w"
             with open(path_table_data, mode) as fh_data:
-                self.dump_table(frame=df, file=t.cast(t.TextIO, fh_data))
+                self.dump_table(frame=frame, file=t.cast(t.TextIO, fh_data))
+            self.data_file_count += 1
+        except Exception as ex:
+            logger.warning(f"Could not export data of {schema}.{tablename}: {ex}")
+            self.data_failures.append({"schema": schema, "table": tablename, "reason": f"{type(ex).__name__}: {ex}"})
 
-        logger.info(f"Successfully exported {table_count} system tables")
+    def _save_definitions(self, bundle_path: Path) -> t.Dict[str, int]:
+        """
+        Capture the user's own table and view definitions.
+        """
+        path_tables = bundle_path / ExportSettings.DDL_PATH / ExportSettings.DDL_TABLES_PATH
+        path_views = bundle_path / ExportSettings.DDL_PATH / ExportSettings.DDL_VIEWS_PATH
+        path_tables.mkdir(parents=True, exist_ok=True)
+        path_views.mkdir(parents=True, exist_ok=True)
+        counts = {"tables": 0, "views": 0}
+
+        try:
+            relations = self.schema_capture.relations()
+        except Exception as ex:
+            logger.warning(f"Could not discover user relations: {ex}")
+            return counts
+
+        for relation in tqdm(relations, desc="Capturing definitions", disable=None):
+            schema = relation["table_schema"]
+            name = relation["table_name"]
+            # `SHOW CREATE TABLE` only works on regular tables. Views come from
+            # `information_schema.views` below; anything else is left alone.
+            if relation.get("table_type") != SystemTableKnowledge.BASE_TABLE_TYPE:
+                continue
+            try:
+                ddl = self.schema_capture.table_ddl(schema=schema, table=name)
+                (path_tables / f"{schema}.{name}.sql").write_text(ddl.rstrip() + "\n")
+                counts["tables"] += 1
+            except Exception as ex:
+                logger.warning(f"Could not capture definition of {schema}.{name}: {ex}")
+
+        try:
+            views = self.schema_capture.views()
+        except Exception as ex:
+            logger.warning(f"Could not read view definitions: {ex}")
+            return counts
+
+        for view in views:
+            schema = view["table_schema"]
+            name = view["table_name"]
+            definition = view.get("view_definition")
+            if not definition:
+                continue
+            try:
+                (path_views / f"{schema}.{name}.sql").write_text(definition.rstrip() + "\n")
+                counts["views"] += 1
+            except Exception as ex:
+                logger.warning(f"Could not capture view {schema}.{name}: {ex}")
+
+        return counts
 
 
 class SystemTableImporter:
@@ -212,13 +439,15 @@ class SystemTableImporter:
         self.debug = debug
         self.adapter = DatabaseAdapter(dburi=self.dburi)
 
-    def table_names(self):
+    def table_names(self) -> t.List[str]:
+        """
+        The target table names, as written by the exporter.
+
+        Filenames already carry their schema's prefix (`sys-`, `is-`), and that
+        prefix is part of the restored table's name.
+        """
         path_schema = self.source / ExportSettings.SCHEMA_PATH
-        names = []
-        for item in path_schema.glob("*.sql"):
-            name = item.name.replace(ExportSettings.TABLE_FILENAME_PREFIX, "").replace(".sql", "")
-            names.append(name)
-        return names
+        return sorted(item.stem for item in path_schema.glob("*.sql"))
 
     def load(self):
         path_schema = self.source / ExportSettings.SCHEMA_PATH
@@ -237,10 +466,8 @@ class SystemTableImporter:
 
         table_count = 0
         for tablename in tqdm(self.table_names()):
-            tablename_restored = f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}"
-
-            path_table_schema = path_schema / f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}.sql"
-            path_table_data = path_data / f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}.{self.data_format}"
+            path_table_schema = path_schema / f"{tablename}.sql"
+            path_table_data = path_data / f"{tablename}.{self.data_format}"
 
             # Skip import of non-existing or empty files.
             if not path_table_data.exists() or path_table_data.stat().st_size == 0:
@@ -253,13 +480,13 @@ class SystemTableImporter:
             self.adapter.run_sql(schema_sql)
 
             # Truncate table.
-            self.adapter.run_sql(f"DELETE FROM {self.adapter.quote_relation_name(tablename_restored)};")  # noqa: S608
+            self.adapter.run_sql(f"DELETE FROM {self.adapter.quote_relation_name(tablename)};")  # noqa: S608
 
             # Load data.
             try:
                 df: "pd.DataFrame" = pd.DataFrame.from_records(self.load_table(path_table_data))
                 df.to_sql(
-                    name=tablename_restored,
+                    name=tablename,
                     con=self.adapter.engine,
                     index=False,
                     if_exists="append",

--- a/cratedb_toolkit/cfr/systable.py
+++ b/cratedb_toolkit/cfr/systable.py
@@ -76,9 +76,7 @@ class SystemTableKnowledge:
 
     # Tables whose data is deliberately not collected
     DATA_SKIPLIST: t.Dict[t.Tuple[str, str], str] = {
-        (SYS_SCHEMA, "summits"): (
-            "static dataset shipped with the server"
-        ),
+        (SYS_SCHEMA, "summits"): ("static dataset shipped with the server"),
     }
 
 

--- a/doc/cfr/index.md
+++ b/doc/cfr/index.md
@@ -11,7 +11,7 @@ It is the recommended entry point, and produces one shareable file. See
 :::
 
 The three areas differ in how raw vs. interpreted their output is:
-- `sys-export` / `sys-import` — a raw copy of every `sys.*` and
+- `sys-export` / `sys-import` — a raw copy of every `sys` and
   `information_schema` table, plus your own table and view definitions and a
   manifest describing the collection. **This is the support-case command.**
   See {ref}`cfr-systable`.

--- a/doc/cfr/index.md
+++ b/doc/cfr/index.md
@@ -8,7 +8,6 @@ information collection and recording per `ctk cfr`.
 **Collecting diagnostics for a CrateDB support case? Use `ctk cfr sys-export`.**
 It is the recommended entry point, and produces one shareable file. See
 {ref}`cfr-systable`.
-
 :::
 
 The three areas differ in how raw vs. interpreted their output is:
@@ -17,10 +16,10 @@ The three areas differ in how raw vs. interpreted their output is:
   manifest describing the collection. **This is the support-case command.**
   See {ref}`cfr-systable`.
 - `jobstats collect` / `view` — raw, time-series query statistics, persisted to a schema.
-  `report` / `ui` additionally launch an interpreted. Useful for your own
-  ongoing query analysis. See {ref}`cfr-jobstats`.
+  `report` / `ui` additionally launch an interpreted view on top. Useful for your
+  own ongoing query analysis. See {ref}`cfr-jobstats`.
 - `info record` — a raw snapshot of `ctk info cluster` and `ctk info jobs`,
-  persisted over time. Built on curated, partly interpreted elements. 
+  persisted over time. Built on curated, partly interpreted elements.
   See {ref}`cfr-info`.
 
 ```{toctree}

--- a/doc/cfr/index.md
+++ b/doc/cfr/index.md
@@ -4,11 +4,24 @@
 CrateDB Toolkit provides a few utilities about diagnostics and metadata
 information collection and recording per `ctk cfr`.
 
+:::{important}
+**Collecting diagnostics for a CrateDB support case? Use `ctk cfr sys-export`.**
+It is the recommended entry point, and produces one shareable file. See
+{ref}`cfr-systable`.
+
+:::
+
 The three areas differ in how raw vs. interpreted their output is:
-- `sys-export` / `sys-import` — a true raw copy of every `sys.*` table. See {ref}`cfr-systable`.
+- `sys-export` / `sys-import` — a raw copy of every `sys.*` and
+  `information_schema` table, plus your own table and view definitions and a
+  manifest describing the collection. **This is the support-case command.**
+  See {ref}`cfr-systable`.
 - `jobstats collect` / `view` — raw, time-series query statistics, persisted to a schema.
-  `report` / `ui` additionally launch an interpreted. See {ref}`cfr-jobstats`.
-- `info record` — a raw snapshot of `ctk info cluster` and `ctk info jobs`. See {ref}`cfr-info`.
+  `report` / `ui` additionally launch an interpreted. Useful for your own
+  ongoing query analysis. See {ref}`cfr-jobstats`.
+- `info record` — a raw snapshot of `ctk info cluster` and `ctk info jobs`,
+  persisted over time. Built on curated, partly interpreted elements. 
+  See {ref}`cfr-info`.
 
 ```{toctree}
 :maxdepth: 1

--- a/doc/cfr/systable.md
+++ b/doc/cfr/systable.md
@@ -10,7 +10,7 @@ It collects raw, uninterpreted data only. The other commands under {ref}`cfr`
 and {ref}`cluster-info` present curated or interpreted views for your own use.
 :::
 
-`sys-export` produces a **diagnostics bundle**: a raw copy of every `sys.*` and
+`sys-export` produces a **diagnostics bundle**: a raw copy of every `sys` and
 `information_schema` table, together with your own table and view definitions,
 and a `manifest.json` describing exactly what was and was not collected.
 `sys-import` loads the raw tables from such a bundle back into a cluster for
@@ -67,7 +67,7 @@ replay yourself; `sys-import` does not consume it.
 ```text
 {clustername}/{timestamp}/
 ├── manifest.json            # what this bundle is, and anything that failed
-├── sys/                     # raw `sys.*` tables
+├── sys/                     # raw `sys` tables
 │   ├── schema/
 │   └── data/
 ├── information_schema/      # raw `information_schema` tables
@@ -79,32 +79,53 @@ replay yourself; `sys-import` does not consume it.
 ```
 
 `manifest.json` identifies the collection: cluster name, the cluster's CrateDB
-version, the toolkit version, and the timestamp. Lists anything that could
-not be collected: `schema_failures` for tables whose `.sql` file is missing, and
-`data_failures` for tables whose data could not be read, each with the reason.
+version, the toolkit version, and an ISO 8601 timestamp with a UTC offset, so a
+bundle can be lined up against server logs. It also accounts for everything that
+is not in the bundle: `schema_failures` for tables whose `.sql` file is missing,
+`data_failures` for tables whose data could not be read, `definition_failures`
+for definitions that could not be captured, `data_skipped` for tables whose data
+is deliberately not collected, and `redactions` for values that were blanked out.
 
 ## What the bundle contains
 
 A bundle contains cluster metadata, not the contents of your tables.
 **No rows from your own tables are exported** — the `ddl/` subtree holds table
-and view *definitions* only.
+and view *definitions* only. It covers every schema outside `sys`,
+`information_schema`, `pg_catalog`, and `blob`, which on a managed cluster
+includes schemas created by the platform itself.
 
-Credentials never reach the bundle. CrateDB itself returns
+Stored credentials are kept out of the bundle. CrateDB itself returns
 `sys.users.password`, and `access_key` / `secret_key` in
 `sys.repositories.settings`, already redacted; JWT entries carry issuer,
 audience, and username, but no token material.
 
+Foreign data wrappers are the exception CrateDB does *not* handle for you:
+`information_schema.user_mapping_options` returns a mapping's `password` in
+cleartext to superusers, and `foreign_server_options` returns the connection
+URL, which for JDBC routinely embeds `user=` and `password=`. `sys-export`
+therefore replaces `option_value` in both tables with a redaction marker before
+writing them. `option_name` and every other column are kept, so the bundle still
+shows which servers and mappings exist. `manifest.json` states what was redacted.
+
 One category does warrant a look before sharing: **`sys.jobs_log`, `sys.jobs`,
-`sys.operations_log`, and `sys.sessions` record SQL statements as they were
-executed, including literal values.** If your queries embed personal or
-otherwise sensitive values, those values appear in the bundle. This is the only
-place where data from your tables can be present.
+and `sys.sessions` record SQL statements as they were executed, including
+literal values.** If your queries embed personal or otherwise sensitive values,
+those values appear in the bundle.
+
+That includes statements which *set* a credential. A recent
+`CREATE USER MAPPING ... OPTIONS (password '...')` or
+`CREATE USER ... WITH (password = '...')` is retained in `sys.jobs_log` with the
+literal in place, and no amount of redaction elsewhere changes that. the
+redaction above covers the stored option value, not the statement that wrote it.
+If such a statement may still be in the log, rotate the credential or review
+`sys/data/sys-jobs_log.jsonl` before passing the bundle on.
 
 Beyond that, the bundle describes your cluster rather than its contents: schema
 names, table and column names and comments; user, role, and privilege names;
 client addresses of active sessions; and node hostnames, filesystem paths, and
-OS details. `manifest.json` lists exactly which schemas and tables were
-collected, so a bundle can be reviewed before it is passed on.
+OS details. `manifest.json` records which schemas were collected, how many
+tables and data files were written, and every failure, skip, and redaction, so a
+bundle can be reviewed before it is passed on.
 
 :::{note}
 The `--scrub` option does not apply to `sys-export`. It blanks out information

--- a/doc/cfr/systable.md
+++ b/doc/cfr/systable.md
@@ -2,12 +2,19 @@
 
 # System table exporter
 
-CFR's `sys-export` and `sys-import` commands support collecting and analyzing
-information about CrateDB clusters for support requests and self-service
-debugging.
+:::{important}
+**`ctk cfr sys-export` is the recommended command for collecting diagnostics for
+a CrateDB support case.** Run it, then attach the resulting file to your case.
 
-Output is a true raw copy of every `sys.*` table.
-See {ref}`cluster-info` for the curated alternatives.
+It collects raw, uninterpreted data only. The other commands under {ref}`cfr` 
+and {ref}`cluster-info` present curated or interpreted views for your own use.
+:::
+
+`sys-export` produces a **diagnostics bundle**: a raw copy of every `sys.*` and
+`information_schema` table, together with your own table and view definitions,
+and a `manifest.json` describing exactly what was and was not collected.
+`sys-import` loads the raw tables from such a bundle back into a cluster for
+analysis, one schema subtree at a time.
 
 ## Install
 
@@ -19,21 +26,63 @@ Alternatively, use the Docker image per `ghcr.io/crate/cratedb-toolkit`.
 For more information about installing CrateDB Toolkit, see {ref}`install`.
 :::
 
+## Collecting diagnostics for a support case
+
+```shell
+ctk cfr --cluster-url="crate://localhost:4200/" \
+    sys-export ./diagnostics.tgz
+```
+
+Attach the resulting file to your support case. The log output tells where
+it was written.
+
 ## Synopsis
 
-Export system table information into timestamped directory using
-the pattern `cfr/{clustername}/{timestamp}/sys`.
+Export system table information into a timestamped directory using
+the pattern `cfr/{clustername}/{timestamp}`.
 By default, the working directory is used as the parent folder.
 ```shell
 ctk cfr --cluster-url="crate://localhost:4200/" \
     sys-export file:///var/ctk/cfr
 ```
 
-Import system table information from directory into given schema.
+Give the target a `.tgz` or `.tar.gz` name to receive a single archive file
+instead.
+
+Import a bundle's raw tables back into a cluster for analysis. Point `sys-import`
+at one per-schema subdirectory of the bundle — `sys` or `information_schema` —
+and give it a target schema to restore into.
 ```shell
 ctk cfr --cluster-url="crate://localhost:4200/?schema=case0815" \
     sys-import file://./cfr/crate/2024-04-18T01-13-41/sys
 ```
+
+Table names keep their bundle prefix, so `sys.jobs_log` is restored as
+`"case0815"."sys-jobs_log"`, and `information_schema.columns` as
+`"case0815"."is-columns"`. The `ddl/` subtree is plain SQL for you to read or
+replay yourself; `sys-import` does not consume it.
+
+## Bundle layout
+
+```text
+{clustername}/{timestamp}/
+├── manifest.json            # what this bundle is, and anything that failed
+├── sys/                     # raw `sys.*` tables
+│   ├── schema/
+│   └── data/
+├── information_schema/      # raw `information_schema` tables
+│   ├── schema/
+│   └── data/
+└── ddl/
+    ├── tables/              # your tables, per `SHOW CREATE TABLE`
+    └── views/               # your views
+```
+
+`manifest.json` identifies the collection: cluster name, the cluster's CrateDB
+version, the toolkit version, and the timestamp. Lists anything that could
+not be collected: `schema_failures` for tables whose `.sql` file is missing, and
+`data_failures` for tables whose data could not be read, each with the reason.
+
 
 ## Configuration
 

--- a/doc/cfr/systable.md
+++ b/doc/cfr/systable.md
@@ -6,7 +6,7 @@
 **`ctk cfr sys-export` is the recommended command for collecting diagnostics for
 a CrateDB support case.** Run it, then attach the resulting file to your case.
 
-It collects raw, uninterpreted data only. The other commands under {ref}`cfr` 
+It collects raw, uninterpreted data only. The other commands under {ref}`cfr`
 and {ref}`cluster-info` present curated or interpreted views for your own use.
 :::
 
@@ -83,6 +83,34 @@ version, the toolkit version, and the timestamp. Lists anything that could
 not be collected: `schema_failures` for tables whose `.sql` file is missing, and
 `data_failures` for tables whose data could not be read, each with the reason.
 
+## What the bundle contains
+
+A bundle contains cluster metadata, not the contents of your tables.
+**No rows from your own tables are exported** — the `ddl/` subtree holds table
+and view *definitions* only.
+
+Credentials never reach the bundle. CrateDB itself returns
+`sys.users.password`, and `access_key` / `secret_key` in
+`sys.repositories.settings`, already redacted; JWT entries carry issuer,
+audience, and username, but no token material.
+
+One category does warrant a look before sharing: **`sys.jobs_log`, `sys.jobs`,
+`sys.operations_log`, and `sys.sessions` record SQL statements as they were
+executed, including literal values.** If your queries embed personal or
+otherwise sensitive values, those values appear in the bundle. This is the only
+place where data from your tables can be present.
+
+Beyond that, the bundle describes your cluster rather than its contents: schema
+names, table and column names and comments; user, role, and privilege names;
+client addresses of active sessions; and node hostnames, filesystem paths, and
+OS details. `manifest.json` lists exactly which schemas and tables were
+collected, so a bundle can be reviewed before it is passed on.
+
+:::{note}
+The `--scrub` option does not apply to `sys-export`. It blanks out information
+about the local machine environment in `ctk cfr info record`, not data collected
+from the cluster.
+:::
 
 ## Configuration
 

--- a/doc/info/index.md
+++ b/doc/info/index.md
@@ -10,9 +10,11 @@ A bundle of information inquiry utilities, for diagnostics and more.
 - `ctk cfr info record` — the same snapshot, persisted over time. See {ref}`cfr-info`.
 - `ctk cfr jobstats collect` / `view` — a separate, continuously-collected time series of
   query statistics, not the same data as `ctk info jobs`. See {ref}`cfr-jobstats`.
-- `ctk cfr sys-export` — a true raw dump of every system table, no interpretation. This is
-  the one to reach for when collecting diagnostics for a CrateDB support case.
-  See {ref}`cfr-systable`.
+- `ctk cfr sys-export` - A raw dump of every system table plus your own table and 
+  view definitions, with a manifest describing what was collected, delivered as 
+  one shareable file. No interpretation — that happens on the support side. 
+  This is the recommended entry point, and none of the commands below are a substitute 
+  for it. See {ref}`cfr-systable`.
 :::
 
 ## Install

--- a/doc/info/index.md
+++ b/doc/info/index.md
@@ -10,11 +10,11 @@ A bundle of information inquiry utilities, for diagnostics and more.
 - `ctk cfr info record` — the same snapshot, persisted over time. See {ref}`cfr-info`.
 - `ctk cfr jobstats collect` / `view` — a separate, continuously-collected time series of
   query statistics, not the same data as `ctk info jobs`. See {ref}`cfr-jobstats`.
-- `ctk cfr sys-export` - A raw dump of every system table plus your own table and 
-  view definitions, with a manifest describing what was collected, delivered as 
-  one shareable file. No interpretation — that happens on the support side. 
-  This is the recommended entry point, and none of the commands below are a substitute 
-  for it. See {ref}`cfr-systable`.
+- `ctk cfr sys-export` — a raw dump of every system table plus your own table and
+  view definitions, with a manifest describing what was collected, delivered as
+  one shareable file. No interpretation — that happens on the support side.
+  For a support case, this is the one to reach for; the commands above are not a
+  substitute for it. See {ref}`cfr-systable`.
 :::
 
 ## Install

--- a/tests/cfr/conftest.py
+++ b/tests/cfr/conftest.py
@@ -5,9 +5,12 @@ Test fixtures for CFR diagnostics bundle tests.
 """
 
 import importlib.metadata
+import logging
 
 import pytest
 from verlib2 import Version
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
@@ -59,6 +62,49 @@ TEARDOWN = [
     'DROP TABLE IF EXISTS "doc"."cfr_simple"',
     f'DROP TABLE IF EXISTS "{VALIDATION_SCHEMA}"."cfr_other"',
 ]
+
+
+# CrateDB hands out in the clear do not reach the bundle.
+FDW_SERVER = "ctk_probe"
+FDW_PASSWORD = "cfr-fdw-supersecret"  # noqa: S105
+FDW_URL = "jdbc:postgresql://example.invalid:5432/probe"
+
+FDW_SETUP = [
+    f"CREATE SERVER {FDW_SERVER} FOREIGN DATA WRAPPER jdbc OPTIONS (url '{FDW_URL}')",
+    f"CREATE USER MAPPING FOR CURRENT_USER SERVER {FDW_SERVER} OPTIONS (\"user\" 'alice', password '{FDW_PASSWORD}')",
+]
+
+FDW_TEARDOWN = [
+    f"DROP USER MAPPING IF EXISTS FOR CURRENT_USER SERVER {FDW_SERVER}",
+    f"DROP SERVER IF EXISTS {FDW_SERVER}",
+]
+
+
+@pytest.fixture
+def cfr_foreign_data_wrapper(cratedb):
+    """
+    Provision an FDW server plus user mapping carrying a known password.
+    """
+    adapter = cratedb.database
+
+    def teardown():
+        for stmt in FDW_TEARDOWN:
+            try:
+                adapter.run_sql(stmt)
+            except Exception as ex:  # noqa: PERF203
+                logger.debug(f"Ignoring FDW teardown failure: {stmt}: {ex}")
+
+    teardown()
+    try:
+        for stmt in FDW_SETUP:
+            adapter.run_sql(stmt)
+    except Exception as ex:
+        teardown()
+        pytest.skip(f"Cluster does not permit creating a foreign server: {ex}")
+
+    yield adapter
+
+    teardown()
 
 
 @pytest.fixture

--- a/tests/cfr/conftest.py
+++ b/tests/cfr/conftest.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2021-2026, Crate.io Inc.
+# Distributed under the terms of the AGPLv3 license, see LICENSE.
+"""
+Test fixtures for CFR diagnostics bundle tests.
+"""
+
+import importlib.metadata
+
+import pytest
+from verlib2 import Version
+
+
+@pytest.fixture(scope="session")
+def click_kwargs():
+    """
+    Click 8.2 no longer understands `mix_stderr`.
+    """
+    kwargs = {}
+    click_version = importlib.metadata.version("click")
+    if Version(click_version) < Version("8.2"):
+        kwargs = {"mix_stderr": False}
+    return kwargs
+
+
+VALIDATION_SCHEMA = "testdrive-cfr"
+
+DDL_COMPLEX_TABLE = """
+CREATE TABLE IF NOT EXISTS "doc"."cfr_complex" (
+  id BIGINT,
+  ts TIMESTAMP WITH TIME ZONE,
+  month TIMESTAMP GENERATED ALWAYS AS date_trunc('month', ts),
+  payload OBJECT(DYNAMIC) AS (nested_a TEXT, nested_b ARRAY(INT)),
+  tags ARRAY(TEXT),
+  loc GEO_POINT,
+  vec FLOAT_VECTOR(4),
+  descr TEXT INDEX USING FULLTEXT WITH (analyzer = 'english'),
+  PRIMARY KEY (id, month)
+) PARTITIONED BY (month)
+CLUSTERED INTO 3 SHARDS
+WITH (number_of_replicas = '0', refresh_interval = 5000, codec = 'best_compression')
+"""
+
+DDL_SIMPLE_TABLE = """
+CREATE TABLE IF NOT EXISTS "doc"."cfr_simple" (id INT PRIMARY KEY, name TEXT)
+"""
+
+DDL_VIEW = """
+CREATE VIEW "doc"."cfr_view" AS SELECT id, name FROM "doc"."cfr_simple"
+"""
+
+# A table outside `doc`, to prove schema capture is not limited to the default schema.
+DDL_OTHER_SCHEMA_TABLE = f"""
+CREATE TABLE IF NOT EXISTS "{VALIDATION_SCHEMA}"."cfr_other" (a TEXT)
+"""
+
+TEARDOWN = [
+    'DROP VIEW IF EXISTS "doc"."cfr_view"',
+    'DROP TABLE IF EXISTS "doc"."cfr_complex"',
+    'DROP TABLE IF EXISTS "doc"."cfr_simple"',
+    f'DROP TABLE IF EXISTS "{VALIDATION_SCHEMA}"."cfr_other"',
+]
+
+
+@pytest.fixture
+def cfr_validation_schema(cratedb):
+    """
+    Provision the validation schema from the feature's quickstart guide.
+
+    Yields the database adapter, so test cases can query the cluster directly.
+    """
+    adapter = cratedb.database
+
+    def teardown():
+        for stmt in TEARDOWN:
+            adapter.run_sql(stmt)
+
+    teardown()
+    for stmt in (DDL_SIMPLE_TABLE, DDL_COMPLEX_TABLE, DDL_VIEW, DDL_OTHER_SCHEMA_TABLE):
+        adapter.run_sql(stmt)
+
+    adapter.run_sql('INSERT INTO "doc"."cfr_simple" (id, name) VALUES (1, \'alpha\')')
+    adapter.run_sql('REFRESH TABLE "doc"."cfr_simple"')
+
+    yield adapter
+
+    teardown()

--- a/tests/cfr/test_bundle.py
+++ b/tests/cfr/test_bundle.py
@@ -63,21 +63,19 @@ def test_reported_path_is_the_bundle_root(cratedb, click_kwargs, tmp_path):
 
 def test_summits_data_is_skipped_but_stated(cratedb, click_kwargs, tmp_path):
     """
-    `sys.summits` data is not collected because it is a static dataset, but the manifest states that.
+    `sys.summits` is not collected because it is a static dataset, but the manifest states that.
 
     """
     bundle_path, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
 
     assert not (bundle_path / "sys" / "data" / "sys-summits.jsonl").exists()
+    assert not (bundle_path / "sys" / "schema" / "sys-summits.sql").exists()
 
     skipped = {(item["schema"], item["table"]): item["reason"] for item in manifest["data_skipped"]}
     assert ("sys", "summits") in skipped
     assert skipped[("sys", "summits")], "a skip without a reason is a silent skip"
 
-    if not (bundle_path / "sys" / "schema" / "sys-summits.sql").exists():
-        failures = {item["table"]: item["reason"] for item in manifest["schema_failures"]}
-        assert "summits" in failures
-        assert failures["summits"]
+    assert "summits" not in {item["table"] for item in manifest["schema_failures"]}
 
 
 def test_information_schema_is_exported(cratedb, click_kwargs, tmp_path):

--- a/tests/cfr/test_bundle.py
+++ b/tests/cfr/test_bundle.py
@@ -7,6 +7,7 @@ These assert against what the cluster itself reports, rather than absolute table
 counts, so they do not become version-specific.
 """
 
+import datetime as dt
 import json
 import tarfile
 from pathlib import Path
@@ -18,7 +19,10 @@ pytest.importorskip("polars", reason="Skipping tests because polars is not insta
 from click.testing import CliRunner  # noqa: E402
 
 from cratedb_toolkit.cfr.cli import cli  # noqa: E402
-from cratedb_toolkit.cfr.systable import SystemTableExporter  # noqa: E402
+from cratedb_toolkit.cfr.systable import SchemaCapture, SystemTableExporter, SystemTableKnowledge  # noqa: E402
+from tests.cfr.conftest import FDW_PASSWORD  # noqa: E402
+
+REDACTION_MARKER = SystemTableKnowledge.REDACTION_MARKER
 
 pytestmark = pytest.mark.cfr
 
@@ -57,19 +61,23 @@ def test_reported_path_is_the_bundle_root(cratedb, click_kwargs, tmp_path):
         assert (path / entry).exists(), f"not reachable from the reported path: {entry}"
 
 
-def test_unrepresentable_schema_does_not_cost_the_data(cratedb, click_kwargs, tmp_path):
+def test_summits_data_is_skipped_but_stated(cratedb, click_kwargs, tmp_path):
     """
-    A table whose schema cannot be represented still has its data exported.
+    `sys.summits` data is not collected because it is a static dataset, but the manifest states that.
+
     """
     bundle_path, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
 
-    assert (bundle_path / "sys" / "data" / "sys-summits.jsonl").exists(), "summits data was dropped"
+    assert not (bundle_path / "sys" / "data" / "sys-summits.jsonl").exists()
 
-    # If the schema could not be generated, the bundle says so.
+    skipped = {(item["schema"], item["table"]): item["reason"] for item in manifest["data_skipped"]}
+    assert ("sys", "summits") in skipped
+    assert skipped[("sys", "summits")], "a skip without a reason is a silent skip"
+
     if not (bundle_path / "sys" / "schema" / "sys-summits.sql").exists():
-        failures = {item["table"] for item in manifest["schema_failures"]}
+        failures = {item["table"]: item["reason"] for item in manifest["schema_failures"]}
         assert "summits" in failures
-        assert manifest["schema_failures"][0]["reason"]
+        assert failures["summits"]
 
 
 def test_information_schema_is_exported(cratedb, click_kwargs, tmp_path):
@@ -131,11 +139,84 @@ def test_view_definitions_are_captured(cfr_validation_schema, cratedb, click_kwa
 
     view_file = bundle_path / "ddl" / "views" / "doc.cfr_view.sql"
     assert view_file.exists()
-    assert "cfr_simple" in view_file.read_text()
+    definition = view_file.read_text()
+
+    assert definition.startswith("CREATE OR REPLACE VIEW doc.cfr_view AS\n")
+    assert definition.rstrip().endswith(";")
+    assert "cfr_simple" in definition
     assert manifest["definitions_captured"]["views"] >= 1
 
     # A view must never be written as a table definition.
     assert not (bundle_path / "ddl" / "tables" / "doc.cfr_view.sql").exists()
+
+
+def test_captured_view_replays(cfr_validation_schema, cratedb, click_kwargs, tmp_path):
+    """
+    The captured file is runnable as it stands, and produces a view that returns rows.
+    """
+    bundle_path, _ = export_bundle(cratedb, click_kwargs, tmp_path)
+    definition = (bundle_path / "ddl" / "views" / "doc.cfr_view.sql").read_text()
+
+    cratedb.database.run_sql(definition)
+    assert cratedb.database.run_sql('SELECT id FROM "doc"."cfr_view"', records=True)
+
+
+def test_fdw_credentials_are_redacted(cfr_foreign_data_wrapper, cratedb, click_kwargs, tmp_path):
+    """
+    FDW credentials must not reach the bundle.
+
+    CrateDB returns `user_mapping_options.option_value` in cleartext to
+    superusers, and the exporter usually runs as one. `foreign_server_options`
+    carries the connection URL, which for JDBC routinely embeds credentials.
+    """
+    bundle_path, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
+
+    # The statement logs record every statement as it was executed, so the
+    # `CREATE USER MAPPING` that set up this fixture is in them verbatim.
+    statement_carriers = {"sys-jobs_log.jsonl", "sys-jobs.jsonl", "sys-sessions.jsonl"}
+
+    for path in bundle_path.rglob("*"):
+        if not path.is_file() or path.name in statement_carriers:
+            continue
+        assert FDW_PASSWORD not in path.read_text(errors="replace"), f"credential leaked into {path}"
+
+    mappings = (bundle_path / "information_schema" / "data" / "is-user_mapping_options.jsonl").read_text()
+    assert REDACTION_MARKER in mappings
+    assert "password" in mappings
+
+    redacted = {(item["schema"], item["table"]): item["columns"] for item in manifest["redactions"]}
+    assert redacted[("information_schema", "user_mapping_options")] == ["option_value"]
+    assert redacted[("information_schema", "foreign_server_options")] == ["option_value"]
+
+
+def test_definition_failures_are_recorded_in_the_manifest(
+    cfr_validation_schema, cratedb, click_kwargs, tmp_path, monkeypatch
+):
+    """
+    A definition that could not be captured is named in the manifest.
+    """
+    monkeypatch.setattr(
+        SchemaCapture,
+        "table_ddl",
+        lambda self, schema, table: (_ for _ in ()).throw(PermissionError("simulated definition failure")),
+    )
+    _, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
+
+    assert manifest["definitions_captured"]["tables"] == 0
+    failures = {(item.get("schema"), item.get("name")): item["reason"] for item in manifest["definition_failures"]}
+    assert ("doc", "cfr_simple") in failures
+    assert "PermissionError" in failures[("doc", "cfr_simple")]
+
+
+def test_collected_at_is_an_iso8601_instant(cratedb, click_kwargs, tmp_path):
+    """
+    A bundle is read alongside server logs, so its timestamp must be a real
+    instant with an offset, not just a filesystem-safe string.
+    """
+    _, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
+
+    collected_at = dt.datetime.fromisoformat(manifest["collected_at"])
+    assert collected_at.tzinfo is not None, "timestamp cannot be correlated without an offset"
 
 
 def test_definitions_cover_all_non_system_schemas(cfr_validation_schema, cratedb, click_kwargs, tmp_path):
@@ -212,7 +293,7 @@ def test_data_failures_are_recorded_in_the_manifest(cratedb, click_kwargs, tmp_p
     original_read_table = SystemTableExporter.read_table
 
     def failing_read_table(self, tablename, schema=None):
-        if tablename == "summits":
+        if tablename == "nodes":
             raise PermissionError("simulated read failure")
         return original_read_table(self, tablename=tablename, schema=schema)
 
@@ -220,9 +301,9 @@ def test_data_failures_are_recorded_in_the_manifest(cratedb, click_kwargs, tmp_p
     bundle_path, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
 
     failures = {(item["schema"], item["table"]): item["reason"] for item in manifest["data_failures"]}
-    assert ("sys", "summits") in failures
-    assert "PermissionError" in failures[("sys", "summits")]
-    assert not (bundle_path / "sys" / "data" / "sys-summits.jsonl").exists()
+    assert ("sys", "nodes") in failures
+    assert "PermissionError" in failures[("sys", "nodes")]
+    assert not (bundle_path / "sys" / "data" / "sys-nodes.jsonl").exists()
 
 
 def test_information_schema_subtree_imports(cratedb, click_kwargs, tmp_path):

--- a/tests/cfr/test_bundle.py
+++ b/tests/cfr/test_bundle.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2021-2026, Crate.io Inc.
+# Distributed under the terms of the AGPLv3 license, see LICENSE.
+"""
+Tests for what `ctk cfr sys-export` collects beyond the raw `sys.*` tables.
+
+These assert against what the cluster itself reports, rather than absolute table
+counts, so they do not become version-specific.
+"""
+
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("polars", reason="Skipping tests because polars is not installed")
+
+from click.testing import CliRunner  # noqa: E402
+
+from cratedb_toolkit.cfr.cli import cli  # noqa: E402
+from cratedb_toolkit.cfr.systable import SystemTableExporter  # noqa: E402
+
+pytestmark = pytest.mark.cfr
+
+
+def run_export(cratedb, click_kwargs, target):
+    """
+    Invoke `ctk cfr sys-export`, returning the Click result.
+    """
+    runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb.database.dburi, "CFR_TARGET": str(target)}, **click_kwargs)
+    return runner.invoke(cli, args=f"--debug sys-export {target}", catch_exceptions=False)
+
+
+def export_bundle(cratedb, click_kwargs, tmp_path):
+    """
+    Produce a bundle as a directory tree, returning (bundle_path, manifest).
+    """
+    result = run_export(cratedb, click_kwargs, tmp_path)
+    assert result.exit_code == 0, result.output
+    bundle_path = Path(json.loads(result.stdout)["path"])
+    manifest = json.loads((bundle_path / "manifest.json").read_text())
+    return bundle_path, manifest
+
+
+def test_reported_path_is_the_bundle_root(cratedb, click_kwargs, tmp_path):
+    """
+    The path printed on stdout is the directory a recipient should look at.
+
+    Reporting the `sys/` subtree instead would point past `manifest.json`,
+    `information_schema/`, and `ddl/`.
+    """
+    result = run_export(cratedb, click_kwargs, tmp_path)
+    assert result.exit_code == 0, result.output
+
+    path = Path(json.loads(result.stdout)["path"])
+    for entry in ["manifest.json", "sys", "information_schema", "ddl"]:
+        assert (path / entry).exists(), f"not reachable from the reported path: {entry}"
+
+
+def test_unrepresentable_schema_does_not_cost_the_data(cratedb, click_kwargs, tmp_path):
+    """
+    A table whose schema cannot be represented still has its data exported.
+    """
+    bundle_path, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
+
+    assert (bundle_path / "sys" / "data" / "sys-summits.jsonl").exists(), "summits data was dropped"
+
+    # If the schema could not be generated, the bundle says so.
+    if not (bundle_path / "sys" / "schema" / "sys-summits.sql").exists():
+        failures = {item["table"] for item in manifest["schema_failures"]}
+        assert "summits" in failures
+        assert manifest["schema_failures"][0]["reason"]
+
+
+def test_information_schema_is_exported(cratedb, click_kwargs, tmp_path):
+    """
+    `information_schema` is exported alongside `sys`, under its own prefix.
+    """
+    bundle_path, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
+    assert "information_schema" in manifest["schemas_exported"]
+
+    schema_files = {item.name for item in (bundle_path / "information_schema" / "schema").iterdir()}
+    assert schema_files, "no information_schema schema files written"
+    assert all(name.startswith("is-") for name in schema_files)
+
+    expected = {
+        row["table_name"]
+        for row in cratedb.database.run_sql(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'information_schema'",
+            records=True,
+        )
+    }
+    assert expected == {name[len("is-") : -len(".sql")] for name in schema_files}
+
+
+def test_table_definitions_preserve_every_clause(cfr_validation_schema, cratedb, click_kwargs, tmp_path):
+    """
+    A captured definition is complete enough to rebuild the table.
+
+    Deriving DDL from metadata tables by hand loses exactly these clauses, which
+    is why the definition comes from the cluster's own `SHOW CREATE TABLE`.
+    """
+    bundle_path, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
+    definition = (bundle_path / "ddl" / "tables" / "doc.cfr_complex.sql").read_text()
+
+    for clause in [
+        "GEO_POINT",
+        "FLOAT_VECTOR(4)",
+        "OBJECT(DYNAMIC)",
+        "ARRAY(TEXT)",
+        "GENERATED ALWAYS AS",
+        "INDEX USING FULLTEXT",
+        "analyzer = 'english'",
+        'PRIMARY KEY ("id", "month")',
+        "CLUSTERED INTO 3 SHARDS",
+        'PARTITIONED BY ("month")',
+        "best_compression",
+        "refresh_interval",
+    ]:
+        assert clause in definition, f"missing from captured definition: {clause}"
+
+    assert manifest["definitions_captured"]["tables"] >= 2
+
+
+def test_view_definitions_are_captured(cfr_validation_schema, cratedb, click_kwargs, tmp_path):
+    """
+    Views come from `information_schema.views`, because `SHOW CREATE TABLE`
+    refuses them, and are not mistaken for tables.
+    """
+    bundle_path, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
+
+    view_file = bundle_path / "ddl" / "views" / "doc.cfr_view.sql"
+    assert view_file.exists()
+    assert "cfr_simple" in view_file.read_text()
+    assert manifest["definitions_captured"]["views"] >= 1
+
+    # A view must never be written as a table definition.
+    assert not (bundle_path / "ddl" / "tables" / "doc.cfr_view.sql").exists()
+
+
+def test_definitions_cover_all_non_system_schemas(cfr_validation_schema, cratedb, click_kwargs, tmp_path):
+    """
+    Capture is not limited to the default `doc` schema.
+    """
+    bundle_path, _ = export_bundle(cratedb, click_kwargs, tmp_path)
+    captured = {item.name for item in (bundle_path / "ddl" / "tables").iterdir()}
+
+    assert "doc.cfr_simple.sql" in captured
+    assert "testdrive-cfr.cfr_other.sql" in captured
+    for name in captured:
+        assert not name.startswith(("sys.", "information_schema.", "pg_catalog.", "blob."))
+
+
+def test_archive_top_level_entry_is_meaningful(cratedb, click_kwargs, tmp_path):
+    """
+    An archive unpacks into a name derived from cluster and timestamp, rather
+    than into the random name of the temporary staging directory.
+    """
+    target = tmp_path / "bundle.tgz"
+    assert run_export(cratedb, click_kwargs, target).exit_code == 0
+
+    with tarfile.open(target) as tar:
+        names = tar.getnames()
+
+    top_level = {name.split("/")[0] for name in names}
+    assert len(top_level) == 1, f"archive must have a single root, got {top_level}"
+    root = top_level.pop()
+    assert not root.startswith("tmp"), f"archive rooted at a temporary directory name: {root}"
+
+    second_level = {name.split("/")[1] for name in names if len(name.split("/")) > 1}
+    assert {"sys", "information_schema", "ddl", "manifest.json"}.issubset(second_level)
+
+
+def test_sys_subtree_still_round_trips(cratedb, click_kwargs, tmp_path):
+    """
+    A bundle's `sys/` subtree imports back with no change to the importer.
+
+    This is the guardrail on the layout: `manifest.json`, `information_schema/`,
+    and `ddl/` all sit *above* `sys/` precisely so that this keeps working.
+    """
+    result = run_export(cratedb, click_kwargs, tmp_path)
+    sys_path = Path(json.loads(result.stdout)["path"]) / "sys"
+
+    assert sorted(item.name for item in sys_path.iterdir()) == ["data", "schema"]
+
+    target_schema = "testdrive-roundtrip"
+    runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb.database.dburi}, **click_kwargs)
+    result = runner.invoke(
+        cli,
+        args=f"--cluster-url={cratedb.database.dburi}?schema={target_schema} sys-import {sys_path}",
+        catch_exceptions=False,
+    )
+    try:
+        assert result.exit_code == 0, result.output
+        restored = cratedb.database.run_sql(
+            f"SELECT table_name FROM information_schema.tables WHERE table_schema = '{target_schema}'",  # noqa: S608
+            records=True,
+        )
+        assert restored, "no tables were restored"
+    finally:
+        cratedb.database.run_sql(f'DROP SCHEMA IF EXISTS "{target_schema}" CASCADE')
+
+
+def test_data_failures_are_recorded_in_the_manifest(cratedb, click_kwargs, tmp_path, monkeypatch):
+    """
+    A table whose data could not be read is named in the manifest, not just logged.
+
+    The recipient of a bundle never sees the exporter's log output, so a bundle
+    where reads failed must not be indistinguishable from a complete one — the
+    data *is* the diagnostic payload.
+    """
+    original_read_table = SystemTableExporter.read_table
+
+    def failing_read_table(self, tablename, schema=None):
+        if tablename == "summits":
+            raise PermissionError("simulated read failure")
+        return original_read_table(self, tablename=tablename, schema=schema)
+
+    monkeypatch.setattr(SystemTableExporter, "read_table", failing_read_table)
+    bundle_path, manifest = export_bundle(cratedb, click_kwargs, tmp_path)
+
+    failures = {(item["schema"], item["table"]): item["reason"] for item in manifest["data_failures"]}
+    assert ("sys", "summits") in failures
+    assert "PermissionError" in failures[("sys", "summits")]
+    assert not (bundle_path / "sys" / "data" / "sys-summits.jsonl").exists()
+
+
+def test_information_schema_subtree_imports(cratedb, click_kwargs, tmp_path):
+    """
+    `sys-import` reads any per-schema subtree, not only `sys/`.
+
+    Filenames carry their schema's prefix, so the importer derives table names
+    from them rather than assuming `sys-`.
+    """
+    bundle_path, _ = export_bundle(cratedb, click_kwargs, tmp_path)
+    is_path = bundle_path / "information_schema"
+
+    target_schema = "testdrive-is-import"
+    runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb.database.dburi}, **click_kwargs)
+    result = runner.invoke(
+        cli,
+        args=f"--cluster-url={cratedb.database.dburi}?schema={target_schema} sys-import {is_path}",
+        catch_exceptions=False,
+    )
+    try:
+        assert result.exit_code == 0, result.output
+        restored = {
+            row["table_name"]
+            for row in cratedb.database.run_sql(
+                f"SELECT table_name FROM information_schema.tables WHERE table_schema = '{target_schema}'",  # noqa: S608
+                records=True,
+            )
+        }
+        assert restored, "no tables were restored"
+        assert all(name.startswith("is-") for name in restored), restored
+    finally:
+        cratedb.database.run_sql(f'DROP SCHEMA IF EXISTS "{target_schema}" CASCADE')
+
+
+def test_scrub_is_not_silently_ignored(cratedb, click_kwargs, tmp_path, caplog):
+    """
+    `--scrub` is accepted by the command group but does not apply to raw cluster
+    data. Accepting it without saying so would misrepresent the bundle.
+    """
+    runner = CliRunner(env={"CRATEDB_CLUSTER_URL": cratedb.database.dburi, "CFR_TARGET": str(tmp_path)}, **click_kwargs)
+    result = runner.invoke(cli, args=f"--debug --scrub sys-export {tmp_path}", catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert "`--scrub` has no effect on `sys-export`" in caplog.text

--- a/tests/cfr/test_systable.py
+++ b/tests/cfr/test_systable.py
@@ -183,7 +183,7 @@ def test_cfr_sys_import_success(cratedb, tmp_path, caplog):
 
     # Verify log output.
     assert "Importing system tables from" in caplog.text
-    assert re.search(r"Successfully imported \d+ tables", caplog.text), "Log message missing"
+    assert re.search(r"Successfully imported \d+ system tables", caplog.text), "Log message missing"
 
     # Verify the outcome.
     results = cratedb.database.run_sql("SHOW TABLES", records=True)

--- a/tests/cfr/test_systable.py
+++ b/tests/cfr/test_systable.py
@@ -1,5 +1,4 @@
 # ruff: noqa: E402
-import importlib.metadata
 import json
 import os.path
 import re
@@ -9,7 +8,6 @@ from importlib.resources import files
 from pathlib import Path
 
 import pytest
-from verlib2 import Version
 
 import tests.cfr
 
@@ -27,16 +25,7 @@ def filenames(path: Path):
     return sorted([item.name for item in path.iterdir()])
 
 
-@pytest.fixture(scope="session")
-def click_kwargs():
-    """
-    Click 8.2 no longer understands `mix_stderr`.
-    """
-    kwargs = {}
-    click_version = importlib.metadata.version("click")
-    if Version(click_version) < Version("8.2"):
-        kwargs = {"mix_stderr": False}
-    return kwargs
+EXPORT_SUMMARY_PATTERN = r"Successfully exported \d+ tables from sys, information_schema"
 
 
 def test_cfr_sys_export_success(cratedb, click_kwargs, tmp_path, caplog):
@@ -55,14 +44,16 @@ def test_cfr_sys_export_success(cratedb, click_kwargs, tmp_path, caplog):
 
     # Verify log output.
     assert "Exporting system tables to" in caplog.text
-    assert re.search(r"Successfully exported \d+ system tables", caplog.text), "Log message missing"
+    assert re.search(EXPORT_SUMMARY_PATTERN, caplog.text), "Log message missing"
 
-    # Verify the outcome.
+    # Verify the outcome. The reported path is the bundle root, so everything
+    # the bundle carries is reachable from it.
     path = Path(json.loads(result.stdout)["path"])
-    assert filenames(path) == ["data", "schema"]
+    assert filenames(path) == ["ddl", "information_schema", "manifest.json", "sys"]
+    assert filenames(path / "sys") == ["data", "schema"]
 
-    schema_files = filenames(path / "schema")
-    data_files = filenames(path / "data")
+    schema_files = filenames(path / "sys" / "schema")
+    data_files = filenames(path / "sys" / "data")
 
     assert len(schema_files) >= 19
     assert len(data_files) >= 10
@@ -86,20 +77,20 @@ def test_cfr_sys_export_to_archive_file(cratedb, click_kwargs, tmp_path, caplog)
 
     # Verify log output.
     assert "Exporting system tables to" in caplog.text
-    assert re.search(r"Successfully exported \d+ system tables", caplog.text), "Log message missing"
+    assert re.search(EXPORT_SUMMARY_PATTERN, caplog.text), "Log message missing"
 
     # Verify the outcome.
     path = Path(json.loads(result.stdout)["path"])
     assert "cluster-data.tgz" in path.name
 
+    # Classify by the `sys/` subtree's own directories, not by substring match.
     data_files = []
     schema_files = []
     with tarfile.open(path, "r") as tar:
-        name_list = tar.getnames()
-        for name in name_list:
-            if "data" in name:
+        for name in tar.getnames():
+            if "/sys/data/" in name:
                 data_files.append(name)
-            elif "schema" in name:
+            elif "/sys/schema/" in name:
                 schema_files.append(name)
 
     assert len(schema_files) >= 19
@@ -135,7 +126,7 @@ def test_cfr_sys_export_ensure_table_name_is_quoted(cratedb, click_kwargs, tmp_p
     assert result.exit_code == 0, result.output
 
     path = Path(json.loads(result.stdout)["path"])
-    sys_cluster_table_schema = path / "schema" / "sys-cluster.sql"
+    sys_cluster_table_schema = path / "sys" / "schema" / "sys-cluster.sql"
     with open(sys_cluster_table_schema, "r") as f:
         content = f.read()
         assert '"sys-cluster"' in content, "Table name missing or not quoted"
@@ -192,7 +183,7 @@ def test_cfr_sys_import_success(cratedb, tmp_path, caplog):
 
     # Verify log output.
     assert "Importing system tables from" in caplog.text
-    assert re.search(r"Successfully imported \d+ system tables", caplog.text), "Log message missing"
+    assert re.search(r"Successfully imported \d+ tables", caplog.text), "Log message missing"
 
     # Verify the outcome.
     results = cratedb.database.run_sql("SHOW TABLES", records=True)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Makes `ctk cfr sys-export` a complete, self-describing diagnostics collection, so a single command produces everything a support case needs.

- `information_schema` tables are exported alongside `sys.*`.
- User table definitions are captured via the cluster's own `SHOW CREATE TABLE`. View definitions come from `information_schema.views`.
- Schema reflection and data export now run independently per table. Removed hardcoded blocklist (`summits`).
- Anything that could not be collected is recorded in `manifest.json` file
- A `manifest.json` at the bundle root records cluster name, CrateDB version, toolkit version, timestamp, what was exported, and per-table `schema_failures` and `data_failures` with reasons.
- Archives unpack into `{cluster}-{timestamp}/` instead of the random name of the temporary staging directory.
- `--scrub` now logs a warning on `sys-export` instead of being silently ignored.

- Raw tables moved from `cfr/{cluster}/{timestamp}/` to `cfr/{cluster}/{timestamp}/{schema}/`, alongside new `ddl/` and `manifest.json` entries. `sys-import` takes a per-schema subtree (`.../sys` or `.../information_schema`) and is unchanged for existing bundles.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #870