### PR TITLE
Fix collection error breaking integration test workflows

### DIFF
--- a/tests/cfr/test_jobstats_unit.py
+++ b/tests/cfr/test_jobstats_unit.py
@@ -9,8 +9,10 @@ import typing as t
 
 import pytest
 
-from cratedb_toolkit.cfr import jobstats
-from cratedb_toolkit.model import DatabaseAddress
+pytest.importorskip("queryanonymizer", reason="Skipping tests because queryanonymizer is not installed")
+
+from cratedb_toolkit.cfr import jobstats  # noqa: E402
+from cratedb_toolkit.model import DatabaseAddress  # noqa: E402
 
 pytestmark = pytest.mark.cfr
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
`cratedb_toolkit.cfr.jobstats` imports `queryanonymizer` at module level. That package is only declared in the `cfr` extra, so the six workflows installing narrow extras (DynamoDB, InfluxDB, Kinesis, MongoDB, NLSQL, PyMongo) failed during pytest.

This PR add the module-level `pytest.importorskip` guard.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
